### PR TITLE
Remove the keyboard modifier for joystick buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joystick Gremlin SC - 13.40.9-sc3
+Joystick Gremlin SC - 13.40.9-sc.4
 ================
 
 Joystick Gremlin SC is a customized version of Joystick Gremlin Ex. It is a trial version for mapping game controls directly within Joystick Gremlin and then providing associated mapping files for the game. In this case, the game is Star Citizen. If this version is heavily used (or there is desire expressed to support other games), the mapping functionality will be incorporated back into the Ex version for use by all. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joystick Gremlin SC - 13.40.9-sc2
+Joystick Gremlin SC - 13.40.9-sc3
 ================
 
 Joystick Gremlin SC is a customized version of Joystick Gremlin Ex. It is a trial version for mapping game controls directly within Joystick Gremlin and then providing associated mapping files for the game. In this case, the game is Star Citizen. If this version is heavily used (or there is desire expressed to support other games), the mapping functionality will be incorporated back into the Ex version for use by all. 

--- a/action_plugins/map_to_sc/__init__.py
+++ b/action_plugins/map_to_sc/__init__.py
@@ -264,13 +264,13 @@ class MapToScFunctor(gremlin.base_classes.AbstractFunctor):
         self.axis_value = 0.0
 
         # Include keypresses to avoid mapping conflicts
-        self.ralt = keyboard.g_name_to_key['rightalt']
-        self.rctrl = keyboard.g_name_to_key['rightcontrol']
-        keys = [ [self.ralt.scan_code, self.ralt.is_extended], [self.rctrl.scan_code, self.rctrl.is_extended ] ]
-        self.release = gremlin.macro.Macro()
-        # Execute release in reverse order
-        for key in reversed(keys):
-            self.release.release(gremlin.macro.key_from_code(key[0], key[1]))        
+        # self.alt = keyboard.g_name_to_key['leftalt']
+        # self.ctrl = keyboard.g_name_to_key['leftcontrol']
+        # keys = [ [self.alt.scan_code, self.alt.is_extended], [self.ctrl.scan_code, self.ctrl.is_extended ] ]
+        # self.release = gremlin.macro.Macro()
+        # # Execute release in reverse order
+        # for key in reversed(keys):
+        #     self.release.release(gremlin.macro.key_from_code(key[0], key[1]))        
 
     def process_event(self, event, value):
         if self.input_type == InputType.JoystickAxis:
@@ -295,13 +295,13 @@ class MapToScFunctor(gremlin.base_classes.AbstractFunctor):
                     and event.is_pressed \
                     and self.needs_auto_release:
                 
-                # Press Keyboard Combo - Right CTRL + Right ALT
-                keyboard.send_key_down(keyboard.key_from_code(self.ralt.scan_code, self.ralt.is_extended))
-                keyboard.send_key_down(keyboard.key_from_code(self.rctrl.scan_code, self.rctrl.is_extended))
-                input_devices.ButtonReleaseActions().register_callback(
-                        lambda: self.release_alt_ctrl(),
-                        event
-                )                    
+                # # Press Keyboard Combo - Right CTRL + Right ALT
+                # keyboard.send_key_down(keyboard.key_from_code(self.alt.scan_code, self.alt.is_extended))
+                # keyboard.send_key_down(keyboard.key_from_code(self.ctrl.scan_code, self.ctrl.is_extended))
+                # input_devices.ButtonReleaseActions().register_callback(
+                #         lambda: self.release_alt_ctrl(),
+                #         event
+                # )                    
 
                 # Release the Vjoy button
                 input_devices.ButtonReleaseActions().register_button_release(
@@ -309,26 +309,24 @@ class MapToScFunctor(gremlin.base_classes.AbstractFunctor):
                     event
                 )
 
-            joystick_handling.VJoyProxy()[self.vjoy_device_id] \
-                .button(self.vjoy_input_id).is_pressed = value.current
+                joystick_handling.VJoyProxy()[self.vjoy_device_id] \
+                    .button(self.vjoy_input_id).is_pressed = value.current
 
             # release the alt and ctrl if not pressed anymore
-            if event.is_pressed == False:
-                keyboard.send_key_up(keyboard.key_from_code(self.ralt.scan_code, self.ralt.is_extended))
-                keyboard.send_key_up(keyboard.key_from_code(self.rctrl.scan_code,  self.rctrl.is_extended))
-                
-
-
+            # if event.is_pressed == False:
+            #     keyboard.send_key_up(keyboard.key_from_code(self.alt.scan_code, self.alt.is_extended))
+            #     keyboard.send_key_up(keyboard.key_from_code(self.ctrl.scan_code,  self.ctrl.is_extended))
+               
         elif self.input_type == InputType.JoystickHat:
 
             joystick_handling.VJoyProxy()[self.vjoy_device_id] \
-                .hat(self.vjoy_input_id).direction = value.current
+                .hat(self.vjoy_input_id).direction = value.currents
 
         return True
 
-    def release_alt_ctrl(self):
-        keyboard.send_key_up(keyboard.key_from_code(self.ralt.scan_code, self.ralt.is_extended))
-        keyboard.send_key_up(keyboard.key_from_code(self.rctrl.scan_code,  self.rctrl.is_extended))
+    # def release_alt_ctrl(self):
+    #     keyboard.send_key_up(keyboard.key_from_code(self.alt.scan_code, self.alt.is_extended))
+    #     keyboard.send_key_up(keyboard.key_from_code(self.ctrl.scan_code,  self.ctrl.is_extended))
 
 
     def relative_axis_thread(self):

--- a/generate_wix.py
+++ b/generate_wix.py
@@ -226,11 +226,11 @@ def create_document():
             #"Id": "6472cca8-d352-4186-8a98-ca6ba33d083c", # 13.40.6ex
             #"Id": "7cdb8375-66a1-4114-be79-b17027e8c0df", # 13.40.7ex
             #"Id": "739095a7-19cc-4154-ac9c-c51f5f516527", # 13.40.8ex
-            "ProductCode": "325af7d7-ee58-4598-879d-f849efce67e7", # 13.40.9-sc3
+            "ProductCode": "3d13fe2c-909e-4a4b-9fe3-665adaae5456", # 13.40.9-sc.4
             "UpgradeCode": "1f5d614b-6cec-47d8-90e3-40f7e7458f7a",
             "Language": "1033",
             "Codepage": "1252",
-            "Version": "13.40.9-sc3",
+            "Version": version,
             "InstallerVersion": "100"
         })
     
@@ -238,6 +238,7 @@ def create_document():
     
     mug = create_node("MajorUpgrade",
         {
+            "AllowSameVersionUpgrades": "yes",
             "DowngradeErrorMessage":
                 "Cannot directly downgrade, uninstall current version first."
         }

--- a/generate_wix.py
+++ b/generate_wix.py
@@ -226,11 +226,11 @@ def create_document():
             #"Id": "6472cca8-d352-4186-8a98-ca6ba33d083c", # 13.40.6ex
             #"Id": "7cdb8375-66a1-4114-be79-b17027e8c0df", # 13.40.7ex
             #"Id": "739095a7-19cc-4154-ac9c-c51f5f516527", # 13.40.8ex
-            "ProductCode": "004a3538-4c1d-4aa9-9770-40da7dfbc785", # 13.40.9-sc2
+            "ProductCode": "325af7d7-ee58-4598-879d-f849efce67e7", # 13.40.9-sc3
             "UpgradeCode": "1f5d614b-6cec-47d8-90e3-40f7e7458f7a",
             "Language": "1033",
             "Codepage": "1252",
-            "Version": "13.40.9-sc2",
+            "Version": "13.40.9-sc3",
             "InstallerVersion": "100"
         })
     

--- a/gremlin/ui/profile_creator.py
+++ b/gremlin/ui/profile_creator.py
@@ -83,7 +83,7 @@ class ProfileCreator(gremlin.ui.common.BaseDialogUi):
             item.always_execute = input_item.always_execute
             item.description = input_item.description
 
-            self.new_profile.devices[event.device_id].modes[mode].set_data(
+            self.new_profile.devices[event.device_guid].modes[mode].set_data(
                 item.input_type,
                 item.input_id,
                 item
@@ -111,6 +111,7 @@ class ProfileCreator(gremlin.ui.common.BaseDialogUi):
 
         # Create the drawers for each of the modes
         self.toolbox = QtWidgets.QToolBox()
+        self.main_layout.addWidget(self.toolbox)
         for i, mode in enumerate(self._mode_list()):
             self.mode_index[mode] = i
             self.toolbox.addItem(
@@ -119,11 +120,12 @@ class ProfileCreator(gremlin.ui.common.BaseDialogUi):
                     self.new_profile,
                     self._binding_registry,
                     mode,
-                    self.update_binding
+                    self.update_binding,
+                    self.toolbox
                 ),
                 mode
             )
-        self.main_layout.addWidget(self.toolbox)
+
 
         # Create the help text indicating how to use the template tool
         self.help_text = QtWidgets.QLabel(
@@ -357,10 +359,7 @@ class BindableAction(QtWidgets.QWidget):
         )
 
         # Display the dialog centered in the middle of the UI
-        root = self
-        while root.parent():
-            root = root.parent()
-        geom = root.geometry()
+        geom = self.topLevelWidget().geometry()
 
         self.button_press_dialog.setGeometry(
             int(geom.x() + geom.width() / 2 - 150),

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -63,7 +63,7 @@ from gremlin.ui.ui_gremlin import Ui_Gremlin
 from gremlin.input_devices import remote_state
 
 APPLICATION_NAME = "Joystick Gremlin SC"
-APPLICATION_VERSION = "13.40.9-sc3"
+APPLICATION_VERSION = "13.40.9-sc.4"
 
 
 class GremlinUi(QtWidgets.QMainWindow):

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -63,7 +63,7 @@ from gremlin.ui.ui_gremlin import Ui_Gremlin
 from gremlin.input_devices import remote_state
 
 APPLICATION_NAME = "Joystick Gremlin SC"
-APPLICATION_VERSION = "13.40.9-sc2"
+APPLICATION_VERSION = "13.40.9-sc3"
 
 
 class GremlinUi(QtWidgets.QMainWindow):


### PR DESCRIPTION
Removed the right alt and ctrl buttons from being pressed. They were being ignored by Star Citizen and since all buttons are being remapped, preserving buttons from previous bindings is not an issue.