### PR TITLE
Fix mappings not working after controls mapping update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joystick Gremlin SC - 13.40.9-sc.6
+Joystick Gremlin SC - 13.40.9-sc.7
 ================
 
 Joystick Gremlin SC is a customized version of Joystick Gremlin Ex. It is a trial version for mapping game controls directly within Joystick Gremlin and then providing associated mapping files for the game. In this case, the game is Star Citizen. If this version is heavily used (or there is desire expressed to support other games), the mapping functionality will be incorporated back into the Ex version for use by all. 

--- a/about/about.html
+++ b/about/about.html
@@ -19,7 +19,7 @@
 <table width="100%">
     <tr>
         <th width="20%" align="left">Version</th>
-        <td width="*">Release 13.40.9-SC.6</td>
+        <td width="*">Release 13.40.9-SC.7</td>
     </tr>
 </table>
 

--- a/action_plugins/map_to_sc/mapping_reader.py
+++ b/action_plugins/map_to_sc/mapping_reader.py
@@ -40,5 +40,7 @@ class ControlsMappingReader(metaclass=Singleton):
     
 
     def resetControlsMapping(self, controls_mapping):
-        self.controls_list = []
-        self.controls_mapping = controls_mapping
+        # Only reset if the controls_mapping changed
+        if (self.controls_mapping != controls_mapping):
+            self.controls_list = []
+            self.controls_mapping = controls_mapping

--- a/generate_wix.py
+++ b/generate_wix.py
@@ -226,7 +226,7 @@ def create_document():
             #"Id": "6472cca8-d352-4186-8a98-ca6ba33d083c", # 13.40.6ex
             #"Id": "7cdb8375-66a1-4114-be79-b17027e8c0df", # 13.40.7ex
             #"Id": "739095a7-19cc-4154-ac9c-c51f5f516527", # 13.40.8ex
-            "ProductCode": "6bc490bb-a58b-4f68-81d1-b13bd4aa2149", # 13.40.9-sc.6
+            "ProductCode": "dee7f43c-9ae7-4d40-beb8-3ffcf7049f77", # 13.40.9-sc.7
             "UpgradeCode": "1f5d614b-6cec-47d8-90e3-40f7e7458f7a",
             "Language": "1033",
             "Codepage": "1252",

--- a/gremlin/event_handler.py
+++ b/gremlin/event_handler.py
@@ -203,6 +203,9 @@ class EventListener(QtCore.QObject):
 
     # occurs when a new controls mapping is defined
     controls_mapping_changed = QtCore.Signal(str)
+
+    # occurs when a profile needs reload
+    reload_profile = QtCore.Signal(str)
         
 
     def __init__(self):

--- a/gremlin/profile.py
+++ b/gremlin/profile.py
@@ -1470,6 +1470,9 @@ class Profile():
         tree = ElementTree.parse(fname)
         root = tree.getroot()
 
+        # Parse settings entries
+        self.settings.from_xml(root.find("settings"))
+
         # Parse each device into separate DeviceConfiguration objects
         for child in root.iter("device"):
             device = Device(self)
@@ -1515,9 +1518,6 @@ class Profile():
         # Parse merge axis entries
         for child in root.iter("merge-axis"):
             self.merge_axes.append(self._parse_merge_axis(child))
-
-        # Parse settings entries
-        self.settings.from_xml(root.find("settings"))
 
         # Parse plugin entries
         for child in root.findall("plugins/plugin"):

--- a/gremlin/ui/profile_settings.py
+++ b/gremlin/ui/profile_settings.py
@@ -221,6 +221,7 @@ class ControlsMapping(QtWidgets.QGroupBox):
         super().__init__(parent)
 
         self.profile_data = profile_data
+        self.current_text = profile_data.sc_controls_mapping
 
         self.main_layout = QtWidgets.QHBoxLayout(self)
         self._create_ui()
@@ -233,7 +234,10 @@ class ControlsMapping(QtWidgets.QGroupBox):
         line_edit = QtWidgets.QLineEdit()
         line_edit.setText(self.profile_data.sc_controls_mapping)
         line_edit.textChanged.connect(self._update_cb)
+        line_button = QtWidgets.QPushButton("Update Profile")
+        line_button.clicked.connect(self._update_profile)
         self.main_layout.addWidget(line_edit)
+        self.main_layout.addWidget(line_button)
         self.main_layout.addStretch()
 
     def _update_cb(self, text):
@@ -241,10 +245,14 @@ class ControlsMapping(QtWidgets.QGroupBox):
 
         :param index the index of the entry selected
         """
-        self.profile_data.sc_controls_mapping = text
+        self.current_text = text
+
+    def _update_profile(self):
+        self.profile_data.sc_controls_mapping = self.current_text
         el = gremlin.event_handler.EventListener()
         el.controls_mapping_changed.emit(self.profile_data.sc_controls_mapping)
-
+        config = gremlin.config.Configuration()
+        el.reload_profile.emit(config.last_profile)
 
 class VJoyAxisDefaultsWidget(QtWidgets.QWidget):
 

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -122,6 +122,7 @@ class GremlinUi(QtWidgets.QMainWindow):
         self._profile = gremlin.profile.Profile()
         self._profile_fname = None
         self._profile_auto_activated = False
+
         # Input selection storage
         self._last_input_timestamp = time.time()
         self._last_input_event = None
@@ -148,6 +149,9 @@ class GremlinUi(QtWidgets.QMainWindow):
             self._do_load_profile(self.config.last_profile)
         else:
             self.new_profile()
+
+        # hook to allow reload of profiles
+        el.reload_profile.connect(self._do_reload_profile)
 
         # Setup the recent files menu
         self._create_recent_profiles()
@@ -1103,6 +1107,14 @@ class GremlinUi(QtWidgets.QMainWindow):
         :return function which will load the specified profile
         """
         return lambda: self._load_recent_profile(fname)
+    
+    def _do_reload_profile(self, fname):
+        """Prompts the user to select a profile file to load."""
+        if not self._save_changes_request():
+            return
+        # Reload after save        
+        self._do_load_profile(fname)
+
 
     def _do_load_profile(self, fname):
         """Load the profile with the given filename.

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -64,7 +64,7 @@ from gremlin.ui.ui_gremlin import Ui_Gremlin
 from gremlin.input_devices import remote_state
 
 APPLICATION_NAME = "Joystick Gremlin SC"
-APPLICATION_VERSION = "13.40.9-sc.6"
+APPLICATION_VERSION = "13.40.9-sc.7"
 
 
 class GremlinUi(QtWidgets.QMainWindow):


### PR DESCRIPTION
This version fixes issue #10 by using the Controls Mapping vJoy inputs (device/input_id) instead of the vJoy inputs in the Profile. This avoids the vjoy inputs becoming stale. Going forward vjoy inputs will not be stored in the profile, but having them in a profile will not cause any issues. 