### PR TITLE
13.40.14-sc.5 - Fixes and support for 4.6.x

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/generate_wix.py",
-            "args": [ "--folder", "joystick_gremlin", "--version", "13.40.14-sc.4"],
+            "args": [ "--folder", "joystick_gremlin", "--version", "13.40.14-sc.5"],
             "cwd": "${workspaceFolder}/dist",
             "console": "integratedTerminal",
             "env": {"PYTHONPATH": "${workspaceFolder};${env:PYTHONPATH}"}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joystick Gremlin SC - 13.40.14-sc.4
+Joystick Gremlin SC - 13.40.14-sc.5
 ================
 
 Joystick Gremlin SC is a customized version of Joystick Gremlin Ex. It is a trial version for mapping game controls directly within Joystick Gremlin and then providing associated mapping files for the game. In this case, the game is Star Citizen. This version has incorporate changes made to Ex up to version 13.30.14ex (m22), but will not incorporate any additional versions. 
@@ -13,7 +13,7 @@ SC Added Features
 - At initialization and changing of modes, refreshes each vJoy axis to match the current joystick values
 
 Current Support:
-- 4.5.x
+- 4.6.x
 
 <hr style="border:3px solid gray">
 
@@ -25,8 +25,7 @@ Joystick Gremlin Ex - 13.40.14ex (m22)
 ## Contents
 
 <!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
-
-- [Joystick Gremlin SC - 13.40.14-sc.4](#joystick-gremlin-sc---134014-sc4)
+- [Joystick Gremlin SC - 13.40.14-sc.5](#joystick-gremlin-sc---134014-sc5)
   - [SC Added Features](#sc-added-features)
 - [Joystick Gremlin Ex - 13.40.14ex (m22)](#joystick-gremlin-ex---134014ex-m22)
   - [Contents](#contents)

--- a/about/about.html
+++ b/about/about.html
@@ -18,7 +18,7 @@
 <table width="100%">
     <tr>
         <th width="20%" align="left">Version</th>
-        <td width="*">Release 13.40.14-SC.4</td>
+        <td width="*">Release 13.40.14-SC.5</td>
     </tr>
 </table>
 

--- a/action_plugins/map_to_sc/__init__.py
+++ b/action_plugins/map_to_sc/__init__.py
@@ -284,14 +284,15 @@ class MapToScFunctor(gremlin.base_classes.AbstractFunctor):
             eh.runtime_mode_changed.connect(self._mode_changed_cb)                
 
     def _mode_changed_cb(self):
-            current_joy_value = self.joy.axis(self.hardware_input_id).value
-            el = gremlin.event_handler.EventListener()            
-            el.joystick_event.emit(gremlin.event_handler.Event(
-                    event_type=InputType.JoystickAxis,
-                    device_guid=self.device_guid,
-                    identifier=self.hardware_input_id,
-                    value=current_joy_value
-                ))            
+            if self.joy is not None:
+                current_joy_value = self.joy.axis(self.hardware_input_id).value
+                el = gremlin.event_handler.EventListener()            
+                el.joystick_event.emit(gremlin.event_handler.Event(
+                        event_type=InputType.JoystickAxis,
+                        device_guid=self.device_guid,
+                        identifier=self.hardware_input_id,
+                        value=current_joy_value
+                    ))            
 
 
     def process_event(self, event, value):

--- a/action_plugins/response_curve/__init__.py
+++ b/action_plugins/response_curve/__init__.py
@@ -1338,16 +1338,9 @@ class ResponseCurveWidget(gremlin.ui.input_item.AbstractActionWidget):
 
         # Update curve settings UI
         if self.action_data.mapping_type == "cubic-spline":
-            if self.handle_symmetry is not None:
-                self.handle_symmetry.setVisible(False)
-                self.handle_symmetry = None
+            self.handle_symmetry.setVisible(False)
         elif self.action_data.mapping_type == "cubic-bezier-spline":
             self.handle_symmetry.setVisible(True)
-            self.handle_symmetry.stateChanged.connect(
-                self._handle_symmetry_cb
-            )
-            
-        self.curve_symmetry.setChecked(False)
 
         # Recreate the UI components
         self.curve_scene = CurveView(

--- a/controls_mappings/StarCitizenControlsMapping-4.6.x-OnFoot.json
+++ b/controls_mappings/StarCitizenControlsMapping-4.6.x-OnFoot.json
@@ -1,0 +1,6454 @@
+[
+    {
+        "category_id": 10,
+        "name": "Vehicles - Seats and Operator Modes",
+        "values": [
+            {
+                "name": "Emergency Exit Seat",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 1,
+                "actionmap": "seat_general",
+                "action": "v_emergency_exit"
+            },
+            {
+                "name": "Eject",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 2,
+                "actionmap": "seat_general",
+                "action": "v_eject"
+            },
+            {
+                "name": "Look Behind",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 3,
+                "actionmap": "seat_general",
+                "action": "v_view_look_behind"
+            },
+            {
+                "name": "Toggle Mining Operator Mode",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 4,
+                "actionmap": "seat_general",
+                "action": "v_toggle_mining_mode"
+            },
+            {
+                "name": "Toggle Salvage Operator Mode",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 5,
+                "actionmap": "seat_general",
+                "action": "v_toggle_salvage_mode"
+            },
+            {
+                "name": "Toggle Scanning Operator Mode",
+                "id": 33,
+                "type": "button",
+                "vjoy": 1,
+                "button": 6,
+                "actionmap": "seat_general",
+                "action": "v_toggle_scan_mode"
+            },
+            {
+                "name": "Toggle Quantum Operator Mode",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 7,
+                "actionmap": "seat_general",
+                "action": "v_toggle_quantum_mode"
+            },
+            {
+                "name": "Toggle Missile Operator Mode",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 8,
+                "actionmap": "seat_general",
+                "action": "v_toggle_missile_mode"
+            },
+            {
+                "name": "Toggle Guns Operator Mode",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 9,
+                "actionmap": "seat_general",
+                "action": "v_toggle_guns_mode"
+            },
+            {
+                "name": "Toggle Flight Operator Mode",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 10,
+                "actionmap": "seat_general",
+                "action": "v_toggle_flight_mode"
+            },
+            {
+                "name": "Set Mining Operator Mode",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 11,
+                "actionmap": "seat_general",
+                "action": "v_set_mining_mode"
+            },
+            {
+                "name": "Set Salvage Operator Mode",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 12,
+                "actionmap": "seat_general",
+                "action": "v_set_salvage_mode"
+            },
+            {
+                "name": "Set Scanning Operator Mode",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 13,
+                "actionmap": "seat_general",
+                "action": "v_set_scan_mode"
+            },
+            {
+                "name": "Set Quantum Operator Mode",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 14,
+                "actionmap": "seat_general",
+                "action": "v_set_quantum_mode"
+            },
+            {
+                "name": "Set Missile Operator Mode",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 15,
+                "actionmap": "seat_general",
+                "action": "v_set_missile_mode"
+            },
+            {
+                "name": "Set Guns Operator Mode",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 16,
+                "actionmap": "seat_general",
+                "action": "v_set_guns_mode"
+            },
+            {
+                "name": "Set Flight Operator Mode",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 17,
+                "actionmap": "seat_general",
+                "action": "v_set_flight_mode"
+            },
+            {
+                "name": "Next Operator Mode",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 18,
+                "actionmap": "seat_general",
+                "action": "v_operator_mode_cycle_forward"
+            },
+            {
+                "name": "Previous Operator Mode",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 19,
+                "actionmap": "seat_general",
+                "action": "v_operator_mode_cycle_back"
+            },
+            {
+                "name": "Enter Remote Turret 1",
+                "id": 110,
+                "type": "button",
+                "vjoy": 1,
+                "button": 20,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_1"
+            },
+            {
+                "name": "Enter Remote Turret 2",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 21,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_2"
+            },
+            {
+                "name": "Enter Remote Turret 3",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 22,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_3"
+            },
+            {
+                "name": "Light Amplificaton Toggle",
+                "id": 125,
+                "type": "button",
+                "vjoy": 1,
+                "button": 23,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_toggle"
+            },
+            {
+                "name": "Light Amplificaton On",
+                "id": 130,
+                "type": "button",
+                "vjoy": 1,
+                "button": 24,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_on"
+            },
+            {
+                "name": "Light Amplificaton Off",
+                "id": 135,
+                "type": "button",
+                "vjoy": 1,
+                "button": 25,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_off"
+            }
+        ]
+    },
+    {
+        "category_id": 15,
+        "name": "Vehicles - Cockpit",
+        "values": [
+            {
+                "name": "Self Destruct",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 26,
+                "actionmap": "spaceship_general",
+                "action": "v_self_destruct"
+            },
+            {
+                "name": "Increase Cooler Rate",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 27,
+                "actionmap": "spaceship_general",
+                "action": "v_cooler_throttle_up"
+            },
+            {
+                "name": "Decrease Cooler Rate",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 28,
+                "actionmap": "spaceship_general",
+                "action": "v_cooler_throttle_down"
+            },
+            {
+                "name": "Flight/Systems Ready",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 29,
+                "actionmap": "spaceship_general",
+                "action": "v_flightready"
+            },
+            {
+                "name": "Open/Close Doors Toggle",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 30,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_doors"
+            },
+            {
+                "name": "Open All Doors",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 31,
+                "actionmap": "spaceship_general",
+                "action": "v_open_all_doors"
+            },
+            {
+                "name": "Close All Doors",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 32,
+                "actionmap": "spaceship_general",
+                "action": "v_close_all_doors"
+            },
+            {
+                "name": "Lock/Unlock Doors Toggle",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 33,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_doorlocks"
+            },
+            {
+                "name": "Lock All Doors",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 34,
+                "actionmap": "spaceship_general",
+                "action": "v_lock_all_doors"
+            },
+            {
+                "name": "Unlock All Doors",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 35,
+                "actionmap": "spaceship_general",
+                "action": "v_unlock_all_doors"
+            },
+            {
+                "name": "Port Lock Toggle All",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 36,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_portlocks"
+            },
+            {
+                "name": "Port Lock All",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 37,
+                "actionmap": "spaceship_general",
+                "action": "v_lock_all_ports"
+            },
+            {
+                "name": "Port Unlock All",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 38,
+                "actionmap": "spaceship_general",
+                "action": "v_unlock_all_ports"
+            }
+        ]
+    },
+    {
+        "category_id": 18,
+        "name": "Vehicles - Multi Function Displays (MFDs)",
+        "values": [
+            {
+                "name": "MFD - Cycle Page - Forwards (short)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 39,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_forwards_short"
+            },
+            {
+                "name": "MFD - Cycle Page - Forwards (long)",
+                "id": 11,
+                "type": "button",
+                "vjoy": 1,
+                "button": 40,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_forwards_long"
+            },
+            {
+                "name": "MFD - Cycle Page - Backwards (short)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 41,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_backwards_short"
+            },
+            {
+                "name": "MFD - Cycle Page - Backwards (long)",
+                "id": 16,
+                "type": "button",
+                "vjoy": 1,
+                "button": 42,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_backwards_long"
+            },
+            {
+                "name": "MFD - Movement - Up (short)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 43,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_up_short"
+            },
+            {
+                "name": "MFD - Movement - Up (long)",
+                "id": 21,
+                "type": "button",
+                "vjoy": 1,
+                "button": 44,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_up_long"
+            },
+            {
+                "name": "MFD - Movement - Down (short)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 45,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_down_short"
+            },
+            {
+                "name": "MFD - Movement - Down (long)",
+                "id": 26,
+                "type": "button",
+                "vjoy": 1,
+                "button": 46,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_down_long"
+            },
+            {
+                "name": "MFD - Movement - Left (short)",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 47,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_left_short"
+            },
+            {
+                "name": "MFD - Movement - Left (long)",
+                "id": 31,
+                "type": "button",
+                "vjoy": 1,
+                "button": 48,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_left_long"
+            },
+            {
+                "name": "MFD - Movement - Right (short)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 49,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_right_short"
+            },
+            {
+                "name": "MFD - Movement - Right (long)",
+                "id": 36,
+                "type": "button",
+                "vjoy": 1,
+                "button": 50,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_right_long"
+            },
+            {
+                "name": "MFD - Select - Primary (short)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 51,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_primary_short"
+            },
+            {
+                "name": "MFD - Select - Primary (long)",
+                "id": 41,
+                "type": "button",
+                "vjoy": 1,
+                "button": 52,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_primary_long"
+            },
+            {
+                "name": "MFD - Select - Left Cast (short)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 53,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_left_short"
+            },
+            {
+                "name": "MFD - Select - Left Cast (long)",
+                "id": 46,
+                "type": "button",
+                "vjoy": 1,
+                "button": 54,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_left_long"
+            },
+            {
+                "name": "MFD - Select - Right Cast (short)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 55,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_right_short"
+            },
+            {
+                "name": "MFD - Select - Right Cast (long)",
+                "id": 51,
+                "type": "button",
+                "vjoy": 1,
+                "button": 56,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_right_long"
+            },
+            {
+                "name": "MFD - Select - MFD 1 (short)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 57,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_1_short"
+            },
+            {
+                "name": "MFD - Select - MFD 1 (long)",
+                "id": 56,
+                "type": "button",
+                "vjoy": 1,
+                "button": 58,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_1_long"
+            },
+            {
+                "name": "MFD - Select - MFD 2 (short)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 59,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_2_short"
+            },
+            {
+                "name": "MFD - Select - MFD 2 (long)",
+                "id": 61,
+                "type": "button",
+                "vjoy": 1,
+                "button": 60,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_2_long"
+            },
+            {
+                "name": "MFD - Select - MFD 3 (short)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 61,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_3_short"
+            },
+            {
+                "name": "MFD - Select - MFD 3 (long)",
+                "id": 66,
+                "type": "button",
+                "vjoy": 1,
+                "button": 62,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_3_long"
+            },
+            {
+                "name": "MFD - Select - MFD 4 (short)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 63,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_4_short"
+            },
+            {
+                "name": "MFD - Select - MFD 4 (long)",
+                "id": 71,
+                "type": "button",
+                "vjoy": 1,
+                "button": 64,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_4_long"
+            },
+            {
+                "name": "MFD - Select - MFD 5 (short)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 65,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_5_short"
+            },
+            {
+                "name": "MFD - Select - MFD 5 (long)",
+                "id": 76,
+                "type": "button",
+                "vjoy": 1,
+                "button": 66,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_5_long"
+            },
+            {
+                "name": "MFD - Select - MFD 6 (short)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 67,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_6_short"
+            },
+            {
+                "name": "MFD - Select - MFD 6 (long)",
+                "id": 81,
+                "type": "button",
+                "vjoy": 1,
+                "button": 68,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_6_long"
+            },
+            {
+                "name": "MFD - Select - MFD 7 (short)",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 69,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_7_short"
+            },
+            {
+                "name": "MFD - Select - MFD 7 (long)",
+                "id": 86,
+                "type": "button",
+                "vjoy": 1,
+                "button": 70,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_7_long"
+            },
+            {
+                "name": "MFD - Select - MFD 8 (short)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 71,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_8_short"
+            },
+            {
+                "name": "MFD - Select - MFD 8 (long)",
+                "id": 91,
+                "type": "button",
+                "vjoy": 1,
+                "button": 72,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_8_long"
+            },
+            {
+                "name": "MFD - Select - MFD 9 (short)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 1,
+                "button": 73,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_9_short"
+            },
+            {
+                "name": "MFD - Select - MFD 9 (long)",
+                "id": 96,
+                "type": "button",
+                "vjoy": 1,
+                "button": 74,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_9_long"
+            },
+            {
+                "name": "MFD - Select - MFD 10 (short)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 75,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_10_short"
+            },
+            {
+                "name": "MFD - Select - MFD 10 (long)",
+                "id": 101,
+                "type": "button",
+                "vjoy": 1,
+                "button": 76,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_10_long"
+            },
+            {
+                "name": "MFD - Quick Action - Self Repair All",
+                "id": 102,
+                "type": "button",
+                "vjoy": 1,
+                "button": 77,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_quick_action_repair_all"
+            },
+            {
+                "name": "MFD - Set Page - Self Status (short)",
+                "id": 103,
+                "type": "button",
+                "vjoy": 1,
+                "button": 78,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_self_status_short"
+            },
+            {
+                "name": "MFD - Set Page - Self Status (long)",
+                "id": 104,
+                "type": "button",
+                "vjoy": 1,
+                "button": 79,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_self_status_long"
+            },
+            {
+                "name": "MFD - Set Page - Target Status (short)",
+                "id": 105,
+                "type": "button",
+                "vjoy": 1,
+                "button": 80,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_target_status_short"
+            },
+            {
+                "name": "MFD - Set Page - Target Status (long)",
+                "id": 106,
+                "type": "button",
+                "vjoy": 1,
+                "button": 81,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_target_status_long"
+            },
+            {
+                "name": "MFD - Set Page - Scanning (short)",
+                "id": 110,
+                "type": "button",
+                "vjoy": 1,
+                "button": 82,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_scanning_short"
+            },
+            {
+                "name": "MFD - Set Page - Scanning (long)",
+                "id": 111,
+                "type": "button",
+                "vjoy": 1,
+                "button": 83,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_scanning_long"
+            },
+            {
+                "name": "MFD - Set Page - Vehicle Config (short)",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 84,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_configuration_short"
+            },
+            {
+                "name": "MFD - Set Page - Vehicle Config (long)",
+                "id": 116,
+                "type": "button",
+                "vjoy": 1,
+                "button": 85,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_configuration_long"
+            },
+            {
+                "name": "MFD - Set Page - Comms (short)",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 86,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_comms_short"
+            },
+            {
+                "name": "MFD - Set Page - Comms (long)",
+                "id": 121,
+                "type": "button",
+                "vjoy": 1,
+                "button": 87,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_comms_long"
+            },
+            {
+                "name": "MFD - Set Page - IFCS (short)",
+                "id": 125,
+                "type": "button",
+                "vjoy": 1,
+                "button": 88,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_ifcs_short"
+            },
+            {
+                "name": "MFD - Set Page - IFCS (long)",
+                "id": 126,
+                "type": "button",
+                "vjoy": 1,
+                "button": 89,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_ifcs_long"
+            },
+            {
+                "name": "MFD - Set Page - Diagnostics (short)",
+                "id": 130,
+                "type": "button",
+                "vjoy": 1,
+                "button": 90,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_diagnostics_short"
+            },
+            {
+                "name": "MFD - Set Page - Diagnostics (long)",
+                "id": 131,
+                "type": "button",
+                "vjoy": 1,
+                "button": 91,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_diagnostics_long"
+            },
+            {
+                "name": "MFD - Set Page - Resource Network (short)",
+                "id": 135,
+                "type": "button",
+                "vjoy": 1,
+                "button": 92,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_resource_network_short"
+            },
+            {
+                "name": "MFD - Set Page - Resource Network (long)",
+                "id": 136,
+                "type": "button",
+                "vjoy": 1,
+                "button": 93,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_resource_network_long"
+            }
+        ]
+    },
+    {
+        "category_id": 20,
+        "name": "Vehicles - View",
+        "values": [
+            {
+                "name": "Look Left",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 94,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw_left"
+            },
+            {
+                "name": "Look Right",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 95,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw_right"
+            },
+            {
+                "name": "Look Left/Right",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 1,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw"
+            },
+            {
+                "name": "Look Up",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 96,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch_up"
+            },
+            {
+                "name": "Look Down",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 97,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch_down"
+            },
+            {
+                "name": "Look Up/Down",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 2,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch"
+            },
+            {
+                "name": "Cycle Camera View",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 98,
+                "actionmap": "spaceship_view",
+                "action": "v_view_cycle_fwd"
+            },
+            {
+                "name": "Cycle Camera Orbit Mode",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 99,
+                "actionmap": "spaceship_view",
+                "action": "v_view_mode"
+            },
+            {
+                "name": "Zoom In (3rd Person View)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 100,
+                "actionmap": "spaceship_view",
+                "action": "v_view_zoom_in"
+            },
+            {
+                "name": "Zoom Out (3rd Person View)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 101,
+                "actionmap": "spaceship_view",
+                "action": "v_view_zoom_out"
+            },
+            {
+                "name": "Freelook (Hold)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 102,
+                "actionmap": "spaceship_view",
+                "action": "v_view_freelook_mode"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (relative)",
+                "id": 65,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 3,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel"
+            },
+            {
+                "name": "Dynamic Zoom In (relative)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 103,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel_in"
+            },
+            {
+                "name": "Dynamic Zoom Out (relative)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 104,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel_out"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (absolute)",
+                "id": 80,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 4,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_abs"
+            },
+            {
+                "name": "Dynamic Zoom Toggle (absolute)",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 105,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_abs_toggle"
+            },
+            {
+                "name": "Precision Targeting - Enable (Hold)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 106,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_hold"
+            },
+            {
+                "name": "Precision Targeting - Toggle",
+                "id": 95,
+                "type": "button",
+                "vjoy": 1,
+                "button": 107,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_toggle"
+            },
+            {
+                "name": "Precision Targeting - Max Zoom (Hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 108,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_stable_max_zoom_hold"
+            },
+            {
+                "name": "Precision Targeting - Toggle Camera Tracking",
+                "id": 105,
+                "type": "button",
+                "vjoy": 1,
+                "button": 109,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_cycle_tracking"
+            }
+        ]
+    },
+    {
+        "category_id": 25,
+        "name": "Flight - Movement",
+        "values": [
+            {
+                "name": "Pitch Up",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 110,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 111,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch_down"
+            },
+            {
+                "name": "Pitch",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch"
+            },
+            {
+                "name": "Yaw Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 112,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw_left"
+            },
+            {
+                "name": "Yaw Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 113,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw_right"
+            },
+            {
+                "name": "Yaw",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw"
+            },
+            {
+                "name": "Roll Left",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 114,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll_left"
+            },
+            {
+                "name": "Roll Right",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 115,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll_right"
+            },
+            {
+                "name": "Roll",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 7,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll"
+            },
+            {
+                "name": "Swap Yaw/Roll",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 116,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_yaw_roll_swap"
+            },
+            {
+                "name": "Strafe Up (absolute)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 117,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_up"
+            },
+            {
+                "name": "Strafe Down (absolute)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 118,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_down"
+            },
+            {
+                "name": "Strafe Up/Down (absolute)",
+                "id": 70,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 8,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_vertical"
+            },
+            {
+                "name": "Strafe Left (absolute)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 119,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_left"
+            },
+            {
+                "name": "Strafe Right (absolute)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 120,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_right"
+            },
+            {
+                "name": "Strafe Left/Right (absolute)",
+                "id": 85,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 1,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_lateral"
+            },
+            {
+                "name": "Throttle Forward/Backward Invert",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 121,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_longitudinal_invert"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 95,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 100,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 105,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 110,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Throttle - Increase",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 122,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_forward"
+            },
+            {
+                "name": "Throttle - Decrease",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 123,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_back"
+            },
+            {
+                "name": "Throttle - Forward / Backward",
+                "id": 125,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 2,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_longitudinal"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 130,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 135,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 140,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Throttle - Cruise Mode - Toggle",
+                "id": 142,
+                "type": "button",
+                "vjoy": 1,
+                "button": 124,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_swap_mode"
+            },
+            {
+                "name": "Throttle - Cruise Mode - Enable",
+                "id": 143,
+                "type": "button",
+                "vjoy": 1,
+                "button": 125,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_set_sticky"
+            },
+            {
+                "name": "Throttle - Cruise Mode - Disable",
+                "id": 144,
+                "type": "button",
+                "vjoy": 1,
+                "button": 126,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_set_normal"
+            },
+            {
+                "name": "Throttle - Trim - Set (long)",
+                "id": 145,
+                "type": "button",
+                "vjoy": 1,
+                "button": 127,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_long"
+            },
+            {
+                "name": "Throttle - Trim - Set (short)",
+                "id": 150,
+                "type": "button",
+                "vjoy": 1,
+                "button": 128,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_short"
+            },
+            {
+                "name": "Throttle - Trim - Set to 100% (long)",
+                "id": 152,
+                "type": "button",
+                "vjoy": 2,
+                "button": 1,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_100_long"
+            },
+            {
+                "name": "Throttle - Trim - Set to 100% (short)",
+                "id": 154,
+                "type": "button",
+                "vjoy": 2,
+                "button": 2,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_100_short"
+            },
+            {
+                "name": "Throttle - Trim - Set to 50% (long)",
+                "id": 156,
+                "type": "button",
+                "vjoy": 2,
+                "button": 3,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_50_long"
+            },
+            {
+                "name": "Throttle - Trim - Set to 50% (short)",
+                "id": 158,
+                "type": "button",
+                "vjoy": 2,
+                "button": 4,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_50_short"
+            },
+            {
+                "name": "Throttle - Trim - Release (long)",
+                "id": 160,
+                "type": "button",
+                "vjoy": 2,
+                "button": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_reset_long"
+            },
+            {
+                "name": "Throttle - Trim - Release (short)",
+                "id": 161,
+                "type": "button",
+                "vjoy": 2,
+                "button": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_reset_short"
+            },
+            {
+                "name": "Enable/Disable Decoupled Mode",
+                "id": 165,
+                "type": "button",
+                "vjoy": 2,
+                "button": 7,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_toggle"
+            },
+            {
+                "name": "Enable Decoupled Mode",
+                "id": 166,
+                "type": "button",
+                "vjoy": 2,
+                "button": 8,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_on"
+            },
+            {
+                "name": "Disable Decoupled Mode",
+                "id": 167,
+                "type": "button",
+                "vjoy": 2,
+                "button": 9,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_off"
+            },
+            {
+                "name": "Boost",
+                "id": 170,
+                "type": "button",
+                "vjoy": 2,
+                "button": 10,
+                "actionmap": "spaceship_movement",
+                "action": "v_afterburner"
+            },
+            {
+                "name": "Speed Limiter - Increase",
+                "id": 175,
+                "type": "button",
+                "vjoy": 2,
+                "button": 11,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_up"
+            },
+            {
+                "name": "Speed Limiter - Decrease",
+                "id": 180,
+                "type": "button",
+                "vjoy": 2,
+                "button": 12,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_down"
+            },
+            {
+                "name": "Speed Limiter - Step Up",
+                "id": 182,
+                "type": "button",
+                "vjoy": 2,
+                "button": 13,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_decrement"
+            },
+            {
+                "name": "Speed Limiter - Step Down",
+                "id": 183,
+                "type": "button",
+                "vjoy": 2,
+                "button": 14,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_increment"
+            },
+            {
+                "name": "Speed Limiter (relative)",
+                "id": 185,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 3,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_rel"
+            },
+            {
+                "name": "Speed Limiter (absolute)",
+                "id": 190,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 4,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_abs"
+            },
+            {
+                "name": "Speed Limiter - Enable / Disable",
+                "id": 195,
+                "type": "button",
+                "vjoy": 2,
+                "button": 15,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_toggle"
+            },
+            {
+                "name": "Speed Limiter - Enable",
+                "id": 196,
+                "type": "button",
+                "vjoy": 2,
+                "button": 16,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_on"
+            },
+            {
+                "name": "Speed Limiter - Disable",
+                "id": 197,
+                "type": "button",
+                "vjoy": 2,
+                "button": 17,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_off"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 200,
+                "type": "button",
+                "vjoy": 0,
+                "disabled": true,
+                "button": 0,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_reset_scm"
+            },
+            {
+                "name": "Acceleration Limiter - Increase",
+                "id": 202,
+                "type": "button",
+                "vjoy": 2,
+                "button": 18,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_up"
+            },
+            {
+                "name": "Acceleration Limiter - Decrease",
+                "id": 203,
+                "type": "button",
+                "vjoy": 2,
+                "button": 19,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_down"
+            },
+            {
+                "name": "Acceleration Limiter - Step Up",
+                "id": 205,
+                "type": "button",
+                "vjoy": 2,
+                "button": 20,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_increment"
+            },
+            {
+                "name": "Acceleration Limiter - Step Down",
+                "id": 210,
+                "type": "button",
+                "vjoy": 2,
+                "button": 21,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_decrement"
+            },
+            {
+                "name": "Acceleration Limiter (relative)",
+                "id": 215,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_rel"
+            },
+            {
+                "name": "Acceleration Limiter (absolute)",
+                "id": 220,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_abs"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 225,
+                "type": "button",
+                "disabled": true,
+                "vjoy": 0,
+                "button": 0,
+                "actionmap": "spaceship_movement",
+                "action": "v_target_match_vel"
+            },
+            {
+                "name": "Spacebrake",
+                "id": 230,
+                "type": "button",
+                "vjoy": 2,
+                "button": 22,
+                "actionmap": "spaceship_movement",
+                "action": "v_space_brake"
+            },
+            {
+                "name": "Lock Pitch/Yaw Movement (Toggle/Hold)",
+                "id": 235,
+                "type": "button",
+                "vjoy": 2,
+                "button": 23,
+                "actionmap": "spaceship_movement",
+                "action": "v_lock_rotation"
+            },
+            {
+                "name": "G-Force Safety Toggle",
+                "id": 240,
+                "type": "button",
+                "vjoy": 2,
+                "button": 24,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_toggle_gforce_safety"
+            },
+            {
+                "name": "G-Force Safety On",
+                "id": 241,
+                "type": "button",
+                "vjoy": 2,
+                "button": 25,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gsafe_on"
+            },
+            {
+                "name": "G-Force Safety Off",
+                "id": 242,
+                "type": "button",
+                "vjoy": 2,
+                "button": 26,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gsafe_off"
+            },
+            {
+                "name": "E.S.P. - Toggle On/Off (Press)",
+                "id": 245,
+                "type": "button",
+                "vjoy": 2,
+                "button": 27,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_toggle_esp"
+            },
+            {
+                "name": "E.S.P. - Enable Temporarily (Hold)",
+                "id": 250,
+                "type": "button",
+                "vjoy": 2,
+                "button": 28,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_esp_hold"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 255,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Landing System (Toggle)",
+                "id": 260,
+                "type": "button",
+                "vjoy": 2,
+                "button": 29,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_landing_system"
+            },
+            {
+                "name": "Landing System (Deploy)",
+                "id": 265,
+                "type": "button",
+                "vjoy": 2,
+                "button": 30,
+                "actionmap": "spaceship_movement",
+                "action": "v_deploy_landing_system"
+            },
+            {
+                "name": "Landing System (Retract)",
+                "id": 270,
+                "type": "button",
+                "vjoy": 2,
+                "button": 31,
+                "actionmap": "spaceship_movement",
+                "action": "v_retract_landing_system"
+            },
+            {
+                "name": "Toggle VTOL",
+                "id": 275,
+                "type": "button",
+                "vjoy": 2,
+                "button": 32,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_toggle"
+            },
+            {
+                "name": "Enable VTOL",
+                "id": 276,
+                "type": "button",
+                "vjoy": 2,
+                "button": 33,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_on"
+            },
+            {
+                "name": "Disable VTOL",
+                "id": 277,
+                "type": "button",
+                "vjoy": 2,
+                "button": 34,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_off"
+            },
+            {
+                "name": "Expand Configuration",
+                "id": 280,
+                "type": "button",
+                "vjoy": 2,
+                "button": 35,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_deploy"
+            },
+            {
+                "name": "Retract Configuration",
+                "id": 285,
+                "type": "button",
+                "vjoy": 2,
+                "button": 36,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_retract"
+            },
+            {
+                "name": "Cycle Configuration",
+                "id": 290,
+                "type": "button",
+                "vjoy": 2,
+                "button": 37,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_cycle"
+            },
+            {
+                "name": "Autoland",
+                "id": 295,
+                "type": "button",
+                "vjoy": 2,
+                "button": 38,
+                "actionmap": "spaceship_movement",
+                "action": "v_autoland"
+            },
+            {
+                "name": "Requst Landing",
+                "id": 300,
+                "type": "button",
+                "vjoy": 2,
+                "button": 39,
+                "actionmap": "spaceship_movement",
+                "action": "v_atc_request"
+            },
+            {
+                "name": "Request Cargo Loading",
+                "id": 305,
+                "type": "button",
+                "vjoy": 2,
+                "button": 40,
+                "actionmap": "spaceship_movement",
+                "action": "v_atc_loading_area_request"
+            },
+            {
+                "name": "Cycle Master Mode (short)",
+                "id": 310,
+                "type": "button",
+                "vjoy": 2,
+                "button": 41,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_cycle"
+            },
+            {
+                "name": "Cycle Master Mode (long)",
+                "id": 311,
+                "type": "button",
+                "vjoy": 2,
+                "button": 42,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_cycle_long"
+            },
+            {
+                "name": "Set Master Mode to Nav",
+                "id": 312,
+                "type": "button",
+                "vjoy": 2,
+                "button": 43,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_set_nav"
+            },
+            {
+                "name": "Set Master Mode to SCM",
+                "id": 313,
+                "type": "button",
+                "vjoy": 2,
+                "button": 44,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_set_scm"
+            },
+            {
+                "name": "Jump Drive - Request Jump",
+                "id": 315,
+                "type": "button",
+                "vjoy": 2,
+                "button": 45,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_jump_request"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 320,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Toggle",
+                "id": 325,
+                "type": "button",
+                "vjoy": 2,
+                "button": 46,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_toggle"
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Enable",
+                "id": 330,
+                "type": "button",
+                "vjoy": 2,
+                "button": 47,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_on"
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Disable",
+                "id": 335,
+                "type": "button",
+                "vjoy": 2,
+                "button": 48,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_off"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Toggle",
+                "id": 337,
+                "type": "button",
+                "vjoy": 2,
+                "button": 49,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_toggle"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Enable",
+                "id": 338,
+                "type": "button",
+                "vjoy": 2,
+                "button": 50,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_on"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Disable",
+                "id": 339,
+                "type": "button",
+                "vjoy": 2,
+                "button": 51,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_off"
+            },
+            {
+                "name": "Automatic Precision Mode - Toggle",
+                "id": 340,
+                "type": "button",
+                "vjoy": 2,
+                "button": 52,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_toggle"
+            },
+            {
+                "name": "Automatic Precision Mode - Enable",
+                "id": 345,
+                "type": "button",
+                "vjoy": 2,
+                "button": 53,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_on"
+            },
+            {
+                "name": "Automatic Precision Mode - Disable",
+                "id": 350,
+                "type": "button",
+                "vjoy": 2,
+                "button": 54,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_off"
+            },
+            {
+                "name": "IFSC Proximity Assist Toggle",
+                "id": 355,
+                "type": "button",
+                "vjoy": 2,
+                "button": 55,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_toggle"
+            },
+            {
+                "name": "IFSC Proximity Assist On",
+                "id": 360,
+                "type": "button",
+                "vjoy": 2,
+                "button": 56,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_on"
+            },
+            {
+                "name": "IFSC Proximity Assist Off",
+                "id": 365,
+                "type": "button",
+                "vjoy": 2,
+                "button": 57,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_off"
+            },
+            {
+                "name": "IFSC - Stability Toggle",
+                "id": 367,
+                "type": "button",
+                "vjoy": 2,
+                "button": 58,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_toggle"
+            },
+            {
+                "name": "IFSC - Stability On",
+                "id": 368,
+                "type": "button",
+                "vjoy": 2,
+                "button": 59,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_on"
+            },
+            {
+                "name": "IFSC - Stability Off",
+                "id": 369,
+                "type": "button",
+                "vjoy": 2,
+                "button": 60,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_off"
+            },
+            {
+                "name": "Reset Flight Accelerometer",
+                "id": 370,
+                "type": "button",
+                "vjoy": 2,
+                "button": 61,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_reset_gmeter_max"
+            },
+            {
+                "name": "Advanced HUD - Toggle",
+                "id": 375,
+                "type": "button",
+                "vjoy": 2,
+                "button": 62,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_toggle"
+            },
+            {
+                "name": "Advanced HUD - Enable",
+                "id": 380,
+                "type": "button",
+                "vjoy": 2,
+                "button": 63,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_on"
+            },
+            {
+                "name": "Advanced HUD - Disable",
+                "id": 385,
+                "type": "button",
+                "vjoy": 2,
+                "button": 64,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_off"
+            },
+            {
+                "name": "IFSC - Command Behaviour Toggle",
+                "id": 390,
+                "type": "button",
+                "vjoy": 2,
+                "button": 65,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_toggle"
+            },
+            {
+                "name": "IFSC - Command Behaviour On",
+                "id": 400,
+                "type": "button",
+                "vjoy": 2,
+                "button": 66,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_on"
+            },
+            {
+                "name": "IFSC - Command Behaviour Off",
+                "id": 405,
+                "type": "button",
+                "vjoy": 2,
+                "button": 67,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_off"
+            },
+            {
+                "name": "IFSC - Core Toggle",
+                "id": 410,
+                "type": "button",
+                "vjoy": 2,
+                "button": 68,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_toggle"
+            },
+            {
+                "name": "IFSC - Core On",
+                "id": 415,
+                "type": "button",
+                "vjoy": 2,
+                "button": 69,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_on"
+            },
+            {
+                "name": "IFSC - Core Off",
+                "id": 420,
+                "type": "button",
+                "vjoy": 2,
+                "button": 70,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_off"
+            }
+        ]
+    },
+    {
+        "category_id": 30,
+        "name": "Flight - Quantum Travel",
+        "values": [
+            {
+                "name": "Engage Quantum Drive (Hold)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 71,
+                "actionmap": "spaceship_quantum",
+                "action": "v_toggle_qdrive_engagement"
+            }
+        ]
+    },
+    {
+        "category_id": 35,
+        "name": "Flight - Docking",
+        "values": [
+            {
+                "name": "Toggle Docking Mode",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 72,
+                "actionmap": "spaceship_docking",
+                "action": "v_toggle_docking_mode"
+            },
+            {
+                "name": "Invoke Docking",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 73,
+                "actionmap": "spaceship_docking",
+                "action": "v_invoke_docking"
+            },
+            {
+                "name": "Toggle Docking Camera",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 74,
+                "actionmap": "spaceship_docking",
+                "action": "v_dock_toggle_view"
+            }
+        ]
+    },
+    {
+        "category_id": 40,
+        "name": "Vehicles - Targeting",
+        "values": [
+            {
+                "name": "Auto Targeting - Toggle On/Off (long)",
+                "id": 1,
+                "type": "button",
+                "vjoy": 2,
+                "button": 75,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_toggle_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle On/Off (short)",
+                "id": 2,
+                "type": "button",
+                "vjoy": 2,
+                "button": 76,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_toggle_short"
+            },
+            {
+                "name": "Auto Targeting - Toggle On (long)",
+                "id": 4,
+                "type": "button",
+                "vjoy": 2,
+                "button": 77,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_enable_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle On (short)",
+                "id": 5,
+                "type": "button",
+                "vjoy": 2,
+                "button": 78,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_enable_short"
+            },
+            {
+                "name": "Auto Targeting - Toggle Off (long)",
+                "id": 7,
+                "type": "button",
+                "vjoy": 2,
+                "button": 79,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_disable_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle Off (short)",
+                "id": 8,
+                "type": "button",
+                "vjoy": 2,
+                "button": 80,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_disable_short"
+            },
+            {
+                "name": "Pin Index 1 - Lock/Unlock Pinned Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 81,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_1"
+            },
+            {
+                "name": "Pin Index 2 - Lock/Unlock Pinned Target",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 82,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_2"
+            },
+            {
+                "name": "Pin Index 3 - Lock/Unlock Pinned Target",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 83,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_3"
+            },
+            {
+                "name": "Pin Index 1 - Pin/Unpin Selected Target",
+                "id": 25,
+                "type": "button",
+                "vjoy": 2,
+                "button": 84,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_1"
+            },
+            {
+                "name": "Pin Index 2 - Pin/Unpin Selected Target",
+                "id": 30,
+                "type": "button",
+                "vjoy": 2,
+                "button": 85,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_2"
+            },
+            {
+                "name": "Pin Index 3 - Pin/Unpin Selected Target",
+                "id": 35,
+                "type": "button",
+                "vjoy": 2,
+                "button": 86,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_3"
+            },
+            {
+                "name": "Pin Index 1 - Pin/Unpin Selected Target (hold)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 2,
+                "button": 87,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_1_hold"
+            },
+            {
+                "name": "Pin Index 2 - Pin/Unpin Selected Target (hold)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 2,
+                "button": 88,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_2_hold"
+            },
+            {
+                "name": "Pin Index 3 - Pin/Unpin Selected Target (hold)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 2,
+                "button": 89,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_3_hold"
+            },
+            {
+                "name": "Pin Selected Target",
+                "id": 55,
+                "type": "button",
+                "vjoy": 2,
+                "button": 90,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_pin_selected"
+            },
+            {
+                "name": "Unpin Selected Target",
+                "id": 60,
+                "type": "button",
+                "vjoy": 2,
+                "button": 91,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unpin_selected"
+            },
+            {
+                "name": "Pin Selected Target (hold)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 2,
+                "button": 92,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_pin_selected_hold"
+            },
+            {
+                "name": "Unpin Selected Target (hold)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 2,
+                "button": 93,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unpin_selected_hold"
+            },
+            {
+                "name": "Remove All Pinned Targets",
+                "id": 75,
+                "type": "button",
+                "vjoy": 2,
+                "button": 94,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_remove_all_pins"
+            },
+            {
+                "name": "Lock Selected Target",
+                "id": 80,
+                "type": "button",
+                "vjoy": 2,
+                "button": 95,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_lock_selected"
+            },
+            {
+                "name": "Unlock Current Target",
+                "id": 85,
+                "type": "button",
+                "vjoy": 2,
+                "button": 96,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unlock"
+            },
+            {
+                "name": "Enable/Disable Look Ahead",
+                "id": 90,
+                "type": "button",
+                "vjoy": 2,
+                "button": 97,
+                "actionmap": "spaceship_targeting",
+                "action": "v_look_ahead_enable"
+            },
+            {
+                "name": "Enable/Disable Target Padlock (Toggle, Hold)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 2,
+                "button": 98,
+                "actionmap": "spaceship_targeting",
+                "action": "v_look_ahead_start_target_tracking"
+            },
+            {
+                "name": "Auto Zoom On Selected Target On/Off (Toggle, Hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 2,
+                "button": 99,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_tracking_auto_zoom"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 110,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_1"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 115,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_2"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 120,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_3"
+            }
+        ]
+    },
+    {
+        "category_id": 45,
+        "name": "Vehicles - Target Cycling",
+        "values": [
+            {
+                "name": "Lock Target Under Reticle",
+                "id": 1,
+                "type": "button",
+                "vjoy": 2,
+                "button": 100,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_under_reticle"
+            },
+            {
+                "name": "Cycle Lock - In View - Back",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 101,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_back"
+            },
+            {
+                "name": "Cycle Lock - In View - Forward",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 102,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_fwd"
+            },
+            {
+                "name": "Cycle Lock - In View - Under Reticle",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 103,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_reset"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Back",
+                "id": 25,
+                "type": "button",
+                "vjoy": 2,
+                "button": 104,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_back"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Forward",
+                "id": 30,
+                "type": "button",
+                "vjoy": 2,
+                "button": 105,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_fwd"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Reset to First",
+                "id": 35,
+                "type": "button",
+                "vjoy": 2,
+                "button": 106,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_reset"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Back",
+                "id": 40,
+                "type": "button",
+                "vjoy": 2,
+                "button": 107,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_back"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Forward",
+                "id": 45,
+                "type": "button",
+                "vjoy": 2,
+                "button": 108,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_fwd"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Reset to Closest",
+                "id": 50,
+                "type": "button",
+                "vjoy": 2,
+                "button": 109,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_reset"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Back",
+                "id": 55,
+                "type": "button",
+                "vjoy": 2,
+                "button": 110,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_back"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Forward",
+                "id": 60,
+                "type": "button",
+                "vjoy": 2,
+                "button": 111,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_fwd"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Reset to Closest",
+                "id": 65,
+                "type": "button",
+                "vjoy": 2,
+                "button": 112,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_reset"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Back",
+                "id": 70,
+                "type": "button",
+                "vjoy": 2,
+                "button": 113,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_back"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Forward",
+                "id": 75,
+                "type": "button",
+                "vjoy": 2,
+                "button": 114,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_fwd"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Reset to Closest",
+                "id": 80,
+                "type": "button",
+                "vjoy": 2,
+                "button": 115,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_reset"
+            },
+            {
+                "name": "Cycle Lock - All - Back",
+                "id": 85,
+                "type": "button",
+                "vjoy": 2,
+                "button": 116,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_back"
+            },
+            {
+                "name": "Cycle Lock - All - Forward",
+                "id": 90,
+                "type": "button",
+                "vjoy": 2,
+                "button": 117,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_fwd"
+            },
+            {
+                "name": "Cycle Lock - All - Reset to Closest",
+                "id": 95,
+                "type": "button",
+                "vjoy": 2,
+                "button": 118,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_reset"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Back",
+                "id": 100,
+                "type": "button",
+                "vjoy": 2,
+                "button": 119,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_back"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Forward",
+                "id": 110,
+                "type": "button",
+                "vjoy": 2,
+                "button": 120,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_fwd"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Reset to Main Target",
+                "id": 115,
+                "type": "button",
+                "vjoy": 2,
+                "button": 121,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 50,
+        "name": "Flight - Target Hailing",
+        "values": [
+            {
+                "name": "Hail Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 122,
+                "actionmap": "spaceship_target_hailing",
+                "action": "v_target_hail"
+            }
+        ]
+    },
+    {
+        "category_id": 55,
+        "name": "Flight - Radar",
+        "values": [
+            {
+                "name": "Activate Ping (Hold & Release)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 123,
+                "actionmap": "spaceship_radar",
+                "action": "v_invoke_ping"
+            }
+        ]
+    },
+    {
+        "category_id": 60,
+        "name": "Vehicles - Scanning",
+        "values": [
+            {
+                "name": "Activate Scanning",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 124,
+                "actionmap": "spaceship_scanning",
+                "action": "v_scanning_trigger_scan"
+            },
+            {
+                "name": "Increase Scanning Angle",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 125,
+                "actionmap": "spaceship_scanning",
+                "action": "v_inc_scan_focus_level"
+            },
+            {
+                "name": "Decrease Scanning Angle",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 126,
+                "actionmap": "spaceship_scanning",
+                "action": "v_dec_scan_focus_level"
+            }
+        ]
+    },
+    {
+        "category_id": 65,
+        "name": "Vehicles - Mining",
+        "values": [
+            {
+                "name": "Fire Mining Laser (Toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 127,
+                "actionmap": "spaceship_mining",
+                "action": "v_toggle_mining_laser_fire"
+            },
+            {
+                "name": "Switch Mining Laser (Toggle)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 1,
+                "actionmap": "spaceship_mining",
+                "action": "v_toggle_mining_laser_type"
+            },
+            {
+                "name": "Increase Mining Laser Power",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 2,
+                "actionmap": "spaceship_mining",
+                "action": "v_increase_mining_throttle"
+            },
+            {
+                "name": "Decrease Mining Laser Power",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 3,
+                "actionmap": "spaceship_mining",
+                "action": "v_decrease_mining_throttle"
+            },
+            {
+                "name": "Increase/Decrease Mining Laser Power",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 7,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_throttle"
+            },
+            {
+                "name": "Activate Mining Module (Slot 1)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 4,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable1"
+            },
+            {
+                "name": "Activate Mining Module (Slot 2)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 5,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable2"
+            },
+            {
+                "name": "Activate Mining Module (Slot 3)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 6,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable3"
+            },
+            {
+                "name": "Use Permanent Modifier",
+                "id": 47,
+                "type": "button",
+                "vjoy": 3,
+                "button": 7,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_permanent_modifier"
+            },
+            {
+                "name": "Jettison Cargo",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 8,
+                "actionmap": "spaceship_mining",
+                "action": "v_jettison_volatile_cargo"
+            }
+        ]
+    },
+    {
+        "category_id": 70,
+        "name": "Vehicles - Salvaging",
+        "values": [
+            {
+                "name": "Tractor Beam Vehicle - Increase Distance",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 9,
+                "actionmap": "spaceship_salvage",
+                "action": "tractor_beam_vehicle_increase_distance"
+            },
+            {
+                "name": "Tractor Beam Vehicle - Decrease Distance",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 10,
+                "actionmap": "spaceship_salvage",
+                "action": "tractor_beam_vehicle_decrease_distance"
+            },
+            {
+                "name": "Toggle Fire Focused",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 11,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_focused"
+            },
+            {
+                "name": "Toggle Fire Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 12,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_left"
+            },
+            {
+                "name": "Toggle Fire Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 13,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_right"
+            },
+            {
+                "name": "Toggle Fire Fracture",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 14,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_fracture"
+            },
+            {
+                "name": "Toggle Fire Disintegrate",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 15,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_disintegrate"
+            },
+            {
+                "name": "Salvage Mode Gimbal (Toggle)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 16,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_gimbal_mode"
+            },
+            {
+                "name": "Salvage Mode Gimbal Reset",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 17,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_reset_gimbal"
+            },
+            {
+                "name": "Increase Beam Spacing",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 18,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_increase_beam_spacing"
+            },
+            {
+                "name": "Decrease Beam Spacing",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 19,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_decrease_beam_spacing"
+            },
+            {
+                "name": "Relative Beam Spacing",
+                "id": 65,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 8,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_beam_spacing_rel"
+            },
+            {
+                "name": "Absolute Beam Spacing",
+                "id": 70,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 1,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_beam_spacing_abs"
+            },
+            {
+                "name": "Salvage Beam Axis (Toggle)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 20,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_beam_spacing_axis"
+            },
+            {
+                "name": "Cycle Focused Salvage Modifiers",
+                "id": 80,
+                "type": "button",
+                "vjoy": 3,
+                "button": 21,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_focused"
+            },
+            {
+                "name": "Cycle Left Salvage Modifiers",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 22,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_left"
+            },
+            {
+                "name": "Cycle Right Salvage Modifiers",
+                "id": 90,
+                "type": "button",
+                "vjoy": 3,
+                "button": 23,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_right"
+            },
+            {
+                "name": "Cycle Structural Salvage Modifiers",
+                "id": 95,
+                "type": "button",
+                "vjoy": 3,
+                "button": 24,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_structural"
+            },
+            {
+                "name": "Focus All Salvage Heads",
+                "id": 110,
+                "type": "button",
+                "vjoy": 3,
+                "button": 25,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_all_heads"
+            },
+            {
+                "name": "Focus Left Salvage Head",
+                "id": 115,
+                "type": "button",
+                "vjoy": 3,
+                "button": 26,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_left"
+            },
+            {
+                "name": "Focus Right Salvage Head",
+                "id": 120,
+                "type": "button",
+                "vjoy": 3,
+                "button": 27,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_right"
+            },
+            {
+                "name": "Focus Fracture Tool",
+                "id": 125,
+                "type": "button",
+                "vjoy": 3,
+                "button": 28,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_fracture"
+            },
+            {
+                "name": "Focus Disintegration Tool",
+                "id": 130,
+                "type": "button",
+                "vjoy": 3,
+                "button": 29,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_disintegrate"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Up",
+                "id": 135,
+                "type": "button",
+                "vjoy": 3,
+                "button": 30,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_up__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Down",
+                "id": 140,
+                "type": "button",
+                "vjoy": 3,
+                "button": 31,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_down__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Left",
+                "id": 145,
+                "type": "button",
+                "vjoy": 3,
+                "button": 32,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_left__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Right",
+                "id": 150,
+                "type": "button",
+                "vjoy": 3,
+                "button": 33,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_left__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Up",
+                "id": 155,
+                "type": "button",
+                "vjoy": 3,
+                "button": 34,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_up__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Down",
+                "id": 160,
+                "type": "button",
+                "vjoy": 3,
+                "button": 35,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_down__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Left",
+                "id": 165,
+                "type": "button",
+                "vjoy": 3,
+                "button": 36,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_right__left"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Right",
+                "id": 170,
+                "type": "button",
+                "vjoy": 3,
+                "button": 37,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_right__right"
+            }
+        ]
+    },
+    {
+        "category_id": 75,
+        "name": "Turret - Movement",
+        "values": [
+            {
+                "name": "Pitch Up",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 38,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 39,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch_down"
+            },
+            {
+                "name": "Pitch",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 2,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch"
+            },
+            {
+                "name": "Yaw Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 40,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw_left"
+            },
+            {
+                "name": "Yaw Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 41,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw_right"
+            },
+            {
+                "name": "Yaw",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 3,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll_left"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll_right"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll"
+            },
+            {
+                "name": "Toggle Turret Mouse Movement (FPS Style)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 42,
+                "actionmap": "turret_movement",
+                "action": "turret_toggle_mouse_mode"
+            },
+            {
+                "name": "Exit Remote Turret",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 43,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_exit"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_in"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_out"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 75,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_toggle"
+            },
+            {
+                "name": "Turret Gyro Stabilization (Toggle)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 3,
+                "button": 44,
+                "actionmap": "turret_movement",
+                "action": "turret_gyromode"
+            },
+            {
+                "name": "Next Remote Turret",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 45,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_cycle_next"
+            },
+            {
+                "name": "Previous Remote Turrent",
+                "id": 86,
+                "type": "button",
+                "vjoy": 3,
+                "button": 46,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_cycle_prev"
+            }
+        ]
+    },
+    {
+        "category_id": 80,
+        "name": "Turret - Advanced",
+        "values": [
+            {
+                "name": "Turret E.S.P. - Toggle On/Off",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 47,
+                "actionmap": "turret_advanced",
+                "action": "turret_esp_toggle"
+            },
+            {
+                "name": "Turret E.S.P. - Enable Temporarily (Hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 48,
+                "actionmap": "turret_advanced",
+                "action": "turret_esp_hold"
+            },
+            {
+                "name": "Recenter Turret (Hold)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 49,
+                "actionmap": "turret_advanced",
+                "action": "turret_recenter"
+            },
+            {
+                "name": "Turret - Speed Limiter - On/Off (Hold/Toggle)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 50,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_toggle"
+            },
+            {
+                "name": "Turret - Speed Limiter (relative)",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 4,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel"
+            },
+            {
+                "name": "Turret - Speed Limiter - Increase (relative)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 51,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel_increase"
+            },
+            {
+                "name": "Turret - Speed Limiter - Decrease (relative) ",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 52,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel_decrease"
+            },
+            {
+                "name": "Turret - Speed Limiter (absolute)",
+                "id": 45,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 5,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_abs"
+            },
+            {
+                "name": "Cycle Fire Mode (staggered/combined)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 53,
+                "actionmap": "turret_advanced",
+                "action": "turret_change_firemode"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_advanced",
+                "action": "turret_instant_zoom"
+            },
+            {
+                "name": "Turret Change Position",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 54,
+                "actionmap": "turret_advanced",
+                "action": "turret_change_position"
+            }
+        ]
+    },
+    {
+        "category_id": 85,
+        "name": "Vehicles - Weapons",
+        "values": [
+            {
+                "name": "Gimbal Toggle",
+                "id": 5,
+                "type": "button",
+                "vjoy": 3,
+                "button": 55,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_toggle"
+            },
+            {
+                "name": "Gimbal Set to Locked",
+                "id": 6,
+                "type": "button",
+                "vjoy": 3,
+                "button": 56,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_set_locked"
+            },
+            {
+                "name": "Gimbal Set to Unlocked",
+                "id": 7,
+                "type": "button",
+                "vjoy": 3,
+                "button": 57,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_set_unlocked"
+            },
+            {
+                "name": "Gimbal Unlocked Cycle",
+                "id": 7,
+                "type": "button",
+                "vjoy": 3,
+                "button": 58,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_unlocked_cycle_source"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 10,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_all"
+            },
+            {
+                "name": "Aim Type - Cycle",
+                "id": 11,
+                "type": "button",
+                "vjoy": 3,
+                "button": 59,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_cycle"
+            },
+            {
+                "name": "Aim Type - PIP Aiming",
+                "id": 12,
+                "type": "button",
+                "vjoy": 3,
+                "button": 60,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_pip_aiming"
+            },
+            {
+                "name": "Aim Type - Painting",
+                "id": 13,
+                "type": "button",
+                "vjoy": 3,
+                "button": 61,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_painting"
+            },
+            {
+                "name": "Aim Type - Auto",
+                "id": 14,
+                "type": "button",
+                "vjoy": 3,
+                "button": 62,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_auto"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 15,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_group1"
+            },
+            {
+                "name": "Staggered Fire - Toggle",
+                "id": 16,
+                "type": "button",
+                "vjoy": 3,
+                "button": 63,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_toggle"
+            },
+            {
+                "name": "Staggered Fire - On",
+                "id": 17,
+                "type": "button",
+                "vjoy": 3,
+                "button": 64,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_on"
+            },
+            {
+                "name": "Staggered Fire - Off",
+                "id": 18,
+                "type": "button",
+                "vjoy": 3,
+                "button": 65,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_off"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 20,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_group2"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 25,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_manual_gimbal_cycle_source"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 30,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_manual_gimbal_lock_vector"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 35,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_cycle_all"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_cycle_fixed_auto"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_fixed_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_auto_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_manual_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 60,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_fixed"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_manual"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_auto"
+            },
+            {
+                "name": "Suppress Aim Assists (hold)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 66,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_suppress_aim_assists_hold"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 80,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_change_firemode"
+            },
+            {
+                "name": "Toggle Lead/Lag PIPs",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 67,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_toggle_lead_lag"
+            },
+            {
+                "name": "Set Lag PIPs",
+                "id": 90,
+                "type": "button",
+                "vjoy": 3,
+                "button": 68,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_set_lag"
+            },
+            {
+                "name": "Set Lead PIPs",
+                "id": 95,
+                "type": "button",
+                "vjoy": 3,
+                "button": 69,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_set_lead"
+            },
+            {
+                "name": "PIP Combination Type: Toggle",
+                "id": 100,
+                "type": "button",
+                "vjoy": 3,
+                "button": 70,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_toggle"
+            },
+            {
+                "name": "PIP Combination Type: Set One PIP per Weapon",
+                "id": 110,
+                "type": "button",
+                "vjoy": 3,
+                "button": 71,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_set_single"
+            },
+            {
+                "name": "PIP Combination Type: Set One PIP per Weapon Type",
+                "id": 115,
+                "type": "button",
+                "vjoy": 3,
+                "button": 72,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_set_combined_weapon_group"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 120,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "PIP Precision Lines Toggle",
+                "id": 117,
+                "type": "button",
+                "vjoy": 3,
+                "button": 73,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_toggle"
+            },
+            {
+                "name": "PIP Precision Lines On",
+                "id": 118,
+                "type": "button",
+                "vjoy": 3,
+                "button": 74,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_on"
+            },
+            {
+                "name": "PIP Precision Lines Off",
+                "id": 119,
+                "type": "button",
+                "vjoy": 3,
+                "button": 75,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_off"
+            },
+            {
+                "name": "PIP Fading Toggle",
+                "id": 121,
+                "type": "button",
+                "vjoy": 3,
+                "button": 76,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_toggle"
+            },
+            {
+                "name": "PIP Fading On",
+                "id": 122,
+                "type": "button",
+                "vjoy": 3,
+                "button": 77,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_on"
+            },
+            {
+                "name": "PIP Fading Off",
+                "id": 123,
+                "type": "button",
+                "vjoy": 3,
+                "button": 78,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_off"
+            },
+            {
+                "name": "Gunnery UI Magnification Toggle",
+                "id": 125,
+                "type": "button",
+                "vjoy": 3,
+                "button": 79,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_toggle"
+            },
+            {
+                "name": "Gunnery UI Magnification On",
+                "id": 126,
+                "type": "button",
+                "vjoy": 3,
+                "button": 80,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_on"
+            },
+            {
+                "name": "Gunnery UI Magnification Off",
+                "id": 127,
+                "type": "button",
+                "vjoy": 3,
+                "button": 81,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_off"
+            },
+            {
+                "name": "Manual Convergence Distance (relative)",
+                "id": 130,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 6,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel"
+            },
+            {
+                "name": "Manual Convergence Distance - Increase",
+                "id": 131,
+                "type": "button",
+                "vjoy": 3,
+                "button": 82,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel_increase"
+            },
+            {
+                "name": "Manual Convergence Distance - Decrease",
+                "id": 132,
+                "type": "button",
+                "vjoy": 3,
+                "button": 83,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel_decrease"
+            },
+            {
+                "name": "Manual Convergence Distance (absolute)",
+                "id": 140,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 7,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_abs"
+            },
+            {
+                "name": "Manual Convergence Distance - Reset",
+                "id": 145,
+                "type": "button",
+                "vjoy": 3,
+                "button": 84,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_set_default"
+            },
+            {
+                "name": "Weapon Preset - Fire",
+                "id": 150,
+                "type": "button",
+                "vjoy": 3,
+                "button": 85,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_attack"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 1",
+                "id": 151,
+                "type": "button",
+                "vjoy": 3,
+                "button": 86,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns0"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 2",
+                "id": 152,
+                "type": "button",
+                "vjoy": 3,
+                "button": 87,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns1"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 3",
+                "id": 153,
+                "type": "button",
+                "vjoy": 3,
+                "button": 88,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns2"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 4",
+                "id": 154,
+                "type": "button",
+                "vjoy": 3,
+                "button": 89,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns3"
+            },
+            {
+                "name": "Weapon Preset - Next",
+                "id": 155,
+                "type": "button",
+                "vjoy": 3,
+                "button": 90,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_next"
+            },
+            {
+                "name": "Weapon Preset - Previous",
+                "id": 160,
+                "type": "button",
+                "vjoy": 3,
+                "button": 91,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_prev"
+            },
+            {
+                "name": "Weapon Preset - Next (overflow)",
+                "id": 162,
+                "type": "button",
+                "vjoy": 3,
+                "button": 92,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_next_overflow"
+            },
+            {
+                "name": "Weapon Preset - Previous (overflow)",
+                "id": 163,
+                "type": "button",
+                "vjoy": 3,
+                "button": 93,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_prev_overflow"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 165,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_hold"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 170,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_toggle"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 175,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_stable_max_zoom_hold"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 180,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_cycle_tracking"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 1",
+                "id": 185,
+                "type": "button",
+                "vjoy": 3,
+                "button": 94,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns0"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 2",
+                "id": 186,
+                "type": "button",
+                "vjoy": 3,
+                "button": 95,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns1"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 3",
+                "id": 187,
+                "type": "button",
+                "vjoy": 3,
+                "button": 96,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns2"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 4",
+                "id": 188,
+                "type": "button",
+                "vjoy": 3,
+                "button": 97,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns3"
+            },
+            {
+                "name": "Weapon Preset - Set EMPs",
+                "id": 190,
+                "type": "button",
+                "vjoy": 3,
+                "button": 98,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_emp"
+            },
+            {
+                "name": "Weapon Preset - Set Quantum Jammers (short range)",
+                "id": 195,
+                "type": "button",
+                "vjoy": 3,
+                "button": 99,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid_jammer"
+            },
+            {
+                "name": "Weapon Preset - Set Quantum Snares / Pulse (long range)",
+                "id": 200,
+                "type": "button",
+                "vjoy": 3,
+                "button": 100,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid_pulse"
+            },
+            {
+                "name": "Weapon Preset - Set QIDs",
+                "id": 205,
+                "type": "button",
+                "vjoy": 3,
+                "button": 101,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid"
+            }
+        ]
+    },
+    {
+        "category_id": 90,
+        "name": "Vehicles - Missiles",
+        "values": [
+            {
+                "name": "Launch Missiles (Tap)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 102,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_toggle_launch_missile"
+            },
+            {
+                "name": "Launch Missiles (Hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 103,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile"
+            },
+            {
+                "name": "Cycle Next Missle Type",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 104,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_cycle_missile_fwd"
+            },
+            {
+                "name": "Cycle Previous Missle Type",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 105,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_cycle_missile_back"
+            },
+            {
+                "name": "Increase Number of Armed Missiles",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 106,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_increase_max_missiles"
+            },
+            {
+                "name": "Decrease Number of Armed Missiles",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 107,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_decrease_max_missiles"
+            },
+            {
+                "name": "Reset Number of Armed Missiles",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 108,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_reset_max_missiles"
+            },
+            {
+                "name": "Bombs - Toggle Desired Impact Point (tap)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 109,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_toggle_desired_impact_point"
+            },
+            {
+                "name": "Bombs - Toggle Desired Impact Point (hold)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 110,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_toggle_desired_impact_point_hold"
+            },
+            {
+                "name": "Bombs - Increase HUD Range",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 111,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_increase"
+            },
+            {
+                "name": "Bombs - Decrease HUD Range",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 112,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_decrease"
+            },
+            {
+                "name": "Bombs - Reset HUD Range",
+                "id": 65,
+                "type": "button",
+                "vjoy": 3,
+                "button": 113,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_reset"
+            },
+            {
+                "name": "Enable Cinematic Camera (toggle)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 3,
+                "button": 114,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile_cinematic"
+            },
+            {
+                "name": "Enable Cinematic Camera (hold)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 115,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile_cinematic_hold"
+            }
+        ]
+    },
+    {
+        "category_id": 95,
+        "name": "Vehicles - Shields and Countermeasures",
+        "values": [
+            {
+                "name": "Decoy - Launch Burst (tap), Set and Launch Burst (Hold)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 116,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_launch"
+            },
+            {
+                "name": "Decoy - Increase Burst Size",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 117,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_burst_decrease"
+            },
+            {
+                "name": "Decoy - Decrease Burst Size",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 118,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_burst_increase"
+            },
+            {
+                "name": "Decoy - Panic Launch",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 119,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_launch_panic"
+            },
+            {
+                "name": "Noise - Deploy",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 120,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_noise_launch"
+            },
+            {
+                "name": "Raise Shield Level - Front",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 121,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_forward"
+            },
+            {
+                "name": "Raise Shield Level - Back",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 122,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_back"
+            },
+            {
+                "name": "Raise Shield Level - Left",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 123,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_left"
+            },
+            {
+                "name": "Raise Shield Level - Right",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 124,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_right"
+            },
+            {
+                "name": "Raise Shield Level - Top",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 125,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_up"
+            },
+            {
+                "name": "Raise Shield Level - Bottom",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 126,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_down"
+            },
+            {
+                "name": "Reset Shield Level",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 1,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_reset_level"
+            }
+        ]
+    },
+    {
+        "category_id": 100,
+        "name": "Category moved to Flight - Power",
+        "values": [
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 10,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 15,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 20,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 25,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 30,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 35,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 60,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 75,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 80,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 85,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 90,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 95,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 100,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 105,
+        "name": "Flight - Power",
+        "values": [
+            {
+                "name": "Toggle Power - All",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 2,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle"
+            },
+            {
+                "name": "Set Power On",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 3,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_on"
+            },
+            {
+                "name": "Set Power Off",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 4,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_off"
+            },
+            {
+                "name": "Toggle Power - Thrusters",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 5,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_thrusters"
+            },
+            {
+                "name": "Set Thrusters Power On",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 6,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_thrusters_on"
+            },
+            {
+                "name": "Set Thrusters Power Off",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 7,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_thrusters_off"
+            },
+            {
+                "name": "Toggle Power - Shields",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 8,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_shields"
+            },
+            {
+                "name": "Set Shields Power On",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 9,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_shields_on"
+            },
+            {
+                "name": "Set Shields Power Off",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 10,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_shields_off"
+            },
+            {
+                "name": "Toggle Power - Weapons",
+                "id": 55,
+                "type": "button",
+                "vjoy": 4,
+                "button": 11,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_weapons"
+            },
+            {
+                "name": "Set Weapons Power On",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 12,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_weapons_on"
+            },
+            {
+                "name": "Set Weapons Power Off",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 13,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_weapons_off"
+            },
+            {
+                "name": "Decrease Throttle",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 14,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_down"
+            },
+            {
+                "name": "Decrease Throttle to Min",
+                "id": 75,
+                "type": "button",
+                "vjoy": 4,
+                "button": 15,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_min"
+            },
+            {
+                "name": "Increase Throttle",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 16,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_up"
+            },
+            {
+                "name": "Increase Throttle to Max",
+                "id": 85,
+                "type": "button",
+                "vjoy": 4,
+                "button": 17,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_max"
+            },
+            {
+                "name": "Engines - Increase (tap)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 18,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_increase"
+            },
+            {
+                "name": "Engines - Decrease (tap)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 19,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_decrease"
+            },
+            {
+                "name": "Engines - Set to Max (hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 4,
+                "button": 20,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_max"
+            },
+            {
+                "name": "Engines - Set to Min (hold)",
+                "id": 105,
+                "type": "button",
+                "vjoy": 4,
+                "button": 21,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_min"
+            },
+            {
+                "name": "Shields - Increase (tap)",
+                "id": 110,
+                "type": "button",
+                "vjoy": 4,
+                "button": 22,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_increase"
+            },
+            {
+                "name": "Shields - Decrease (tap)",
+                "id": 115,
+                "type": "button",
+                "vjoy": 4,
+                "button": 23,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_decrease"
+            },
+            {
+                "name": "Shields - Set to Max (hold)",
+                "id": 120,
+                "type": "button",
+                "vjoy": 4,
+                "button": 24,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_max"
+            },
+            {
+                "name": "Shields - Set to Min (hold)",
+                "id": 125,
+                "type": "button",
+                "vjoy": 4,
+                "button": 25,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_min"
+            },
+            {
+                "name": "Weapons - Increase (tap)",
+                "id": 130,
+                "type": "button",
+                "vjoy": 4,
+                "button": 26,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_increase"
+            },
+            {
+                "name": "Weapons - Decrease (tap)",
+                "id": 135,
+                "type": "button",
+                "vjoy": 4,
+                "button": 27,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_decrease"
+            },
+            {
+                "name": "Weapons - Set to Max (hold)",
+                "id": 140,
+                "type": "button",
+                "vjoy": 4,
+                "button": 28,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_max"
+            },
+            {
+                "name": "Weapons - Set to Min (hold)",
+                "id": 145,
+                "type": "button",
+                "vjoy": 4,
+                "button": 29,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_min"
+            },
+            {
+                "name": "Reset Assignments",
+                "id": 150,
+                "type": "button",
+                "vjoy": 4,
+                "button": 30,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 110,
+        "name": "Flight - HUD",
+        "values": [
+            {
+                "name": "Cycle Pitch Ladder Mode",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 31,
+                "actionmap": "spaceship_hud",
+                "action": "v_cycle_pitch_ladder_mode"
+            },
+            {
+                "name": "Scoreboard",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 32,
+                "actionmap": "spaceship_hud",
+                "action": "v_hud_open_scoreboard"
+            },
+            {
+                "name": "Map",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 33,
+                "actionmap": "spaceship_hud",
+                "action": "v_starmap"
+            },
+            {
+                "name": "Wipe Helmet Visor",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 34,
+                "actionmap": "spaceship_hud",
+                "action": "visor_wipe"
+            }
+        ]
+    },
+    {
+        "category_id": 115,
+        "name": "Lights",
+        "values": [
+            {
+                "name": "Headlights (toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 35,
+                "actionmap": "lights_controller",
+                "action": "v_lights"
+            },
+            {
+                "name": "Headlights - On",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 36,
+                "actionmap": "lights_controller",
+                "action": "v_lights_on"
+            },
+            {
+                "name": "Headlights - Off",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 37,
+                "actionmap": "lights_controller",
+                "action": "v_lights_off"
+            }
+        ]
+    },
+    {
+        "category_id": 117,
+        "name": "On Foot - All",
+        "values": [
+            {
+                "name": "Move Left",
+                "id": 5,
+                "type": "button",
+                "vjoy": 4,
+                "button": 38,
+                "actionmap": "player",
+                "action": "moveleft"
+            },
+            {
+                "name": "Move Right",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 39,
+                "actionmap": "player",
+                "action": "moveright"
+            },
+            {
+                "name": "Move Forward",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 40,
+                "actionmap": "player",
+                "action": "moveforward"
+            },
+            {
+                "name": "Move Backward",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 41,
+                "actionmap": "player",
+                "action": "moveback"
+            },
+            {
+                "name": "Move Left/Right",
+                "id": 25,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 8,
+                "actionmap": "player",
+                "action": "gp_movex"
+            },
+            {
+                "name": "Move Forward/Backward",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 1,
+                "actionmap": "player",
+                "action": "gp_movey"
+            },
+            {
+                "name": "Look (Yaw)",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 2,
+                "actionmap": "player",
+                "action": "gp_rotateyaw"
+            },
+            {
+                "name": "Look (Pitch)",
+                "id": 40,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 3,
+                "actionmap": "player",
+                "action": "gp_rotatepitch"
+            },
+            {
+                "name": "Jump",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 42,
+                "actionmap": "player",
+                "action": "jump"
+            },
+            {
+                "name": "Jump (hold)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 43,
+                "actionmap": "player",
+                "action": "jump_hold"
+            },
+            {
+                "name": "Jump (release)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 4,
+                "button": 44,
+                "actionmap": "player",
+                "action": "jump_release"
+            },
+            {
+                "name": "Crouch",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 45,
+                "actionmap": "player",
+                "action": "gp_crouch"
+            },
+            {
+                "name": "Prone",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 46,
+                "actionmap": "player",
+                "action": "prone"
+            },
+            {
+                "name": "Sprint",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 47,
+                "actionmap": "player",
+                "action": "sprint"
+            },
+            {
+                "name": "Walk",
+                "id": 75,
+                "type": "button",
+                "vjoy": 4,
+                "button": 48,
+                "actionmap": "player",
+                "action": "walk"
+            },
+            {
+                "name": "Lean Left",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 49,
+                "actionmap": "player",
+                "action": "leanleft"
+            },
+            {
+                "name": "Lean Right",
+                "id": 85,
+                "type": "button",
+                "vjoy": 4,
+                "button": 50,
+                "actionmap": "player",
+                "action": "leanright"
+            },
+            {
+                "name": "Ledge Grap",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 51,
+                "actionmap": "player",
+                "action": "ledgegrab"
+            },
+            {
+                "name": "Firearm - Primary Attack",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 52,
+                "actionmap": "player",
+                "action": "attack1"
+            },
+            {
+                "name": "Firearm - Secondary Attack",
+                "id": 100,
+                "type": "button",
+                "vjoy": 4,
+                "button": 53,
+                "actionmap": "player",
+                "action": "attackSecondary"
+            },
+            {
+                "name": "Melee - Attack Light Left",
+                "id": 105,
+                "type": "button",
+                "vjoy": 4,
+                "button": 54,
+                "actionmap": "player",
+                "action": "melee_AttackLightLeft"
+            },
+            {
+                "name": "Melee - Attack Light Right",
+                "id": 110,
+                "type": "button",
+                "vjoy": 4,
+                "button": 55,
+                "actionmap": "player",
+                "action": "melee_AttackLightRight"
+            },
+            {
+                "name": "Melee - Attack Heavy Left (hold)",
+                "id": 115,
+                "type": "button",
+                "vjoy": 4,
+                "button": 56,
+                "actionmap": "player",
+                "action": "melee_AttackHeavyLeft"
+            },
+            {
+                "name": "Melee - Attack Heavy Right (hold)",
+                "id": 120,
+                "type": "button",
+                "vjoy": 4,
+                "button": 57,
+                "actionmap": "player",
+                "action": "melee_AttackHeavyRight"
+            },
+            {
+                "name": "Melee - Block (Hold)",
+                "id": 125,
+                "type": "button",
+                "vjoy": 4,
+                "button": 58,
+                "actionmap": "player",
+                "action": "melee_block"
+            },
+            {
+                "name": "Medical Pen - Inject Other",
+                "id": 130,
+                "type": "button",
+                "vjoy": 4,
+                "button": 59,
+                "actionmap": "player",
+                "action": "melee_AttackSyringeStab"
+            },
+            {
+                "name": "Melee - Attack",
+                "id": 135,
+                "type": "button",
+                "vjoy": 4,
+                "button": 60,
+                "actionmap": "player",
+                "action": "weapon_melee"
+            },
+            {
+                "name": "Melee - Attack (Ranged Weapon+Takedowns)",
+                "id": 140,
+                "type": "button",
+                "vjoy": 4,
+                "button": 61,
+                "actionmap": "player",
+                "action": "takedown_nonLethal"
+            },
+            {
+                "name": "Throw - Overarm & Two-Handed",
+                "id": 145,
+                "type": "button",
+                "vjoy": 4,
+                "button": 62,
+                "actionmap": "player",
+                "action": "throw_overhand"
+            },
+            {
+                "name": "Throw - Underarm",
+                "id": 150,
+                "type": "button",
+                "vjoy": 4,
+                "button": 63,
+                "actionmap": "player",
+                "action": "throw_underhand"
+            },
+            {
+                "name": "Aim Down Sight",
+                "id": 155,
+                "type": "button",
+                "vjoy": 4,
+                "button": 64,
+                "actionmap": "player",
+                "action": "zoom"
+            },
+            {
+                "name": "Interact with Scope (ADS)",
+                "id": 160,
+                "type": "button",
+                "vjoy": 4,
+                "button": 65,
+                "actionmap": "player",
+                "action": "interact_with_scope"
+            },
+            {
+                "name": "Select Primary Weapon",
+                "id": 165,
+                "type": "button",
+                "vjoy": 4,
+                "button": 66,
+                "actionmap": "player",
+                "action": "select_primary_pit"
+            },
+            {
+                "name": "Select Secondary Weapon",
+                "id": 170,
+                "type": "button",
+                "vjoy": 4,
+                "button": 67,
+                "actionmap": "player",
+                "action": "select_secondary_pit"
+            },
+            {
+                "name": "Select Sidearm",
+                "id": 175,
+                "type": "button",
+                "vjoy": 4,
+                "button": 68,
+                "actionmap": "player",
+                "action": "select_sidearm_pit"
+            },
+            {
+                "name": "Select Melee",
+                "id": 180,
+                "type": "button",
+                "vjoy": 4,
+                "button": 69,
+                "actionmap": "player",
+                "action": "select_meleeweapon_pit"
+            },
+            {
+                "name": "Select Gadget",
+                "id": 185,
+                "type": "button",
+                "vjoy": 4,
+                "button": 70,
+                "actionmap": "player",
+                "action": "select_gadget_pit"
+            },
+            {
+                "name": "Unarmed Combat",
+                "id": 190,
+                "type": "button",
+                "vjoy": 4,
+                "button": 71,
+                "actionmap": "player",
+                "action": "selectUnarmedCombat"
+            },
+            {
+                "name": "Next Weapon",
+                "id": 195,
+                "type": "button",
+                "vjoy": 4,
+                "button": 72,
+                "actionmap": "player",
+                "action": "nextweapon"
+            },
+            {
+                "name": "Previous Weapon",
+                "id": 200,
+                "type": "button",
+                "vjoy": 4,
+                "button": 73,
+                "actionmap": "player",
+                "action": "prevweapon"
+            },
+            {
+                "name": "Reload",
+                "id": 205,
+                "type": "button",
+                "vjoy": 4,
+                "button": 74,
+                "actionmap": "player",
+                "action": "reload"
+            },
+            {
+                "name": "Reload Secondary",
+                "id": 210,
+                "type": "button",
+                "vjoy": 4,
+                "button": 75,
+                "actionmap": "player",
+                "action": "reloadSecondary"
+            },
+            {
+                "name": "Ammo Repool",
+                "id": 215,
+                "type": "button",
+                "vjoy": 4,
+                "button": 76,
+                "actionmap": "player",
+                "action": "ammoRepool"
+            },
+            {
+                "name": "Holster Weapon",
+                "id": 220,
+                "type": "button",
+                "vjoy": 4,
+                "button": 77,
+                "actionmap": "player",
+                "action": "holster"
+            },
+            {
+                "name": "Drop Item",
+                "id": 225,
+                "type": "button",
+                "vjoy": 4,
+                "button": 78,
+                "actionmap": "player",
+                "action": "drop"
+            },
+            {
+                "name": "Inspect Item",
+                "id": 230,
+                "type": "button",
+                "vjoy": 4,
+                "button": 79,
+                "actionmap": "player",
+                "action": "inspect"
+            },
+            {
+                "name": "Customize",
+                "id": 235,
+                "type": "button",
+                "vjoy": 4,
+                "button": 80,
+                "actionmap": "player",
+                "action": "customize"
+            },
+            {
+                "name": "Hold Breath (ADS)",
+                "id": 240,
+                "type": "button",
+                "vjoy": 4,
+                "button": 81,
+                "actionmap": "player",
+                "action": "stabilize"
+            },
+            {
+                "name": "FPS Underbarrel Attachment Action",
+                "id": 245,
+                "type": "button",
+                "vjoy": 4,
+                "button": 82,
+                "actionmap": "player",
+                "action": "weapon_auxiliary_action"
+            },
+            {
+                "name": "Change Fire Mode",
+                "id": 250,
+                "type": "button",
+                "vjoy": 4,
+                "button": 83,
+                "actionmap": "player",
+                "action": "weapon_change_firemode"
+            },
+            {
+                "name": "Weapon Zeroing Decrease",
+                "id": 255,
+                "type": "button",
+                "vjoy": 4,
+                "button": 84,
+                "actionmap": "player",
+                "action": "weapon_zeroing_decrease"
+            },
+            {
+                "name": "Weapon Zeroing Increase / Auto",
+                "id": 260,
+                "type": "button",
+                "vjoy": 4,
+                "button": 85,
+                "actionmap": "player",
+                "action": "weapon_zeroing_increase"
+            },
+            {
+                "name": "Default Movement Speed Increase",
+                "id": 265,
+                "type": "button",
+                "vjoy": 4,
+                "button": 86,
+                "actionmap": "player",
+                "action": "fixed_speed_increment"
+            },
+            {
+                "name": "Default Movement Speed Decrease",
+                "id": 270,
+                "type": "button",
+                "vjoy": 4,
+                "button": 87,
+                "actionmap": "player",
+                "action": "fixed_speed_decrement"
+            },
+            {
+                "name": "Flashlight (Toggle)",
+                "id": 275,
+                "type": "button",
+                "vjoy": 4,
+                "button": 88,
+                "actionmap": "player",
+                "action": "toggle_flashlight"
+            },
+            {
+                "name": "Toggle Equip Helmet",
+                "id": 280,
+                "type": "button",
+                "vjoy": 4,
+                "button": 89,
+                "actionmap": "player",
+                "action": "toggleEquipHelmet"
+            },
+            {
+                "name": "Toggle Attach Helmet",
+                "id": 280,
+                "type": "button",
+                "vjoy": 4,
+                "button": 90,
+                "actionmap": "player",
+                "action": "toggleAttachHelmet"
+            },
+            {
+                "name": "Helmet",
+                "id": 285,
+                "type": "button",
+                "vjoy": 4,
+                "button": 91,
+                "actionmap": "player",
+                "action": "toggleHelmetState"
+            },
+            {
+                "name": "Wipe Helmet Visor",
+                "id": 295,
+                "type": "button",
+                "vjoy": 4,
+                "button": 92,
+                "actionmap": "player",
+                "action": "visor_wipe"
+            },
+            {
+                "name": "Third Person View (Toggle)",
+                "id": 300,
+                "type": "button",
+                "vjoy": 4,
+                "button": 93,
+                "actionmap": "player",
+                "action": "thirdperson"
+            },
+            {
+                "name": "Free View Camera (Hold)",
+                "id": 300,
+                "type": "button",
+                "vjoy": 4,
+                "button": 94,
+                "actionmap": "player",
+                "action": "free_thirdperson_camera"
+            },
+            {
+                "name": "Zoom Out",
+                "id": 305,
+                "type": "button",
+                "vjoy": 4,
+                "button": 95,
+                "actionmap": "player",
+                "action": "zoom_out"
+            },
+            {
+                "name": "Zoom In",
+                "id": 310,
+                "type": "button",
+                "vjoy": 4,
+                "button": 96,
+                "actionmap": "player",
+                "action": "zoom_in"
+            },
+            {
+                "name": "Recall Last Vehicle",
+                "id": 315,
+                "type": "button",
+                "vjoy": 4,
+                "button": 97,
+                "actionmap": "player",
+                "action": "ship_recall"
+            },
+            {
+                "name": "Scoreboard",
+                "id": 320,
+                "type": "button",
+                "vjoy": 4,
+                "button": 98,
+                "actionmap": "player",
+                "action": "pl_hud_open_scoreboard"
+            },
+            {
+                "name": "Consume",
+                "id": 325,
+                "type": "button",
+                "vjoy": 4,
+                "button": 99,
+                "actionmap": "player",
+                "action": "consume"
+            },
+            {
+                "name": "Port Modification Interact",
+                "id": 330,
+                "type": "button",
+                "vjoy": 4,
+                "button": 100,
+                "actionmap": "player",
+                "action": "port_modification_select"
+            },
+            {
+                "name": "Map",
+                "id": 335,
+                "type": "button",
+                "vjoy": 4,
+                "button": 101,
+                "actionmap": "player",
+                "action": "v_starmap"
+            },
+            {
+                "name": "Force Re-spawn (EVA/On Foot)",
+                "id": 340,
+                "type": "button",
+                "vjoy": 4,
+                "button": 102,
+                "actionmap": "player",
+                "action": "force_respawn"
+            },
+            {
+                "name": "Roll Left (while Prone)",
+                "id": 345,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 4,
+                "actionmap": "prone",
+                "action": "prone_rollleft"
+            },
+            {
+                "name": "Roll Right (while Prone)",
+                "id": 350,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 5,
+                "actionmap": "prone",
+                "action": "prone_rollright"
+            },
+            {
+                "name": "Tractor Beam Vehicle - Increase Distance",
+                "id": 355,
+                "type": "button",
+                "vjoy": 4,
+                "button": 103,
+                "actionmap": "tractor_beam",
+                "action": "tractor_beam_increase_distance"
+            },
+            {
+                "name": "Tractor Beam Vehicle - Decrease Distance",
+                "id": 360,
+                "type": "button",
+                "vjoy": 4,
+                "button": 104,
+                "actionmap": "tractor_beam",
+                "action": "tractor_beam_decrease_distance"
+            }
+        ]
+    },
+    {
+        "category_id": 118,
+        "name": "E.V.A. - All",
+        "values": [
+            {
+                "name": "View Left",
+                "id": 5,
+                "type": "button",
+                "vjoy": 4,
+                "button": 105,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_yaw_left"
+            },
+            {
+                "name": "View Right",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 106,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_yaw_right"
+            },
+            {
+                "name": "View Left/Right",
+                "id": 13,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 6,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_yaw"
+            },
+            {
+                "name": "View Up",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 107,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_pitch_up"
+            },
+            {
+                "name": "View Down",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 108,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_pitch_down"
+            },
+            {
+                "name": "View Up/Down",
+                "id": 25,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 7,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_view_pitch"
+            },
+            {
+                "name": "Roll Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 109,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_roll_right"
+            },
+            {
+                "name": "Roll Left",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 110,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_roll_left"
+            },
+            {
+                "name": "Roll Left/Right",
+                "id": 40,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 8,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_roll"
+            },
+            {
+                "name": "Strafe Up",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 111,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_up"
+            },
+            {
+                "name": "Strafe Down",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 112,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_down"
+            },
+            {
+                "name": "Strafe Up/Down",
+                "id": 55,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 1,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_vertical"
+            },
+            {
+                "name": "Stafe Left",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 113,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_left"
+            },
+            {
+                "name": "Strafe Right",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 114,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_right"
+            },
+            {
+                "name": "Strafe Left/Right",
+                "id": 70,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 2,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_lateral"
+            },
+            {
+                "name": "Strafe Forward",
+                "id": 75,
+                "type": "button",
+                "vjoy": 4,
+                "button": 115,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_forward"
+            },
+            {
+                "name": "Strafe Backward",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 116,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_back"
+            },
+            {
+                "name": "Strafe Forward/Backward",
+                "id": 85,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 3,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_strafe_longitudinal"
+            },
+            {
+                "name": "Brake",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 117,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_brake"
+            },
+            {
+                "name": "Boost",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 118,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_boost"
+            },
+            {
+                "name": "Freelook (Hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 4,
+                "button": 119,
+                "actionmap": "zero_gravity_eva",
+                "action": "eva_toggle_headlook_mode"
+            }
+        ]
+    },
+    {
+        "category_id": 119,
+        "name": "E.V.A. - Zero-G Traversal",
+        "values": [
+            {
+                "name": "Launch from Surface",
+                "id": 5,
+                "type": "button",
+                "vjoy": 4,
+                "button": 120,
+                "actionmap": "zero_gravity_traversal",
+                "action": "zgt_launch"
+            },
+            {
+                "name": "Detach onto Surface",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 121,
+                "actionmap": "zero_gravity_traversal",
+                "action": "zgt_detach"
+            },
+            {
+                "name": "Roll Left",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 122,
+                "actionmap": "zero_gravity_traversal",
+                "action": "zgt_roll_left"
+            },
+            {
+                "name": "Roll Right",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 123,
+                "actionmap": "zero_gravity_traversal",
+                "action": "zgt_roll_right"
+            }
+        ]
+    },
+    {
+        "category_id": 120,
+        "name": "Ground Vehicle - General",
+        "values": [
+            {
+                "name": "Horn",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 124,
+                "actionmap": "vehicle_general",
+                "action": "v_horn"
+            },
+            {
+                "name": "Cycle Camera View",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 125,
+                "actionmap": "vehicle_general",
+                "action": "v_view_cycle_fwd"
+            },
+            {
+                "name": "Zoom In (3rd Person View)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 1,
+                "actionmap": "vehicle_general",
+                "action": "v_view_zoom_in"
+            },
+            {
+                "name": "Zoom Out (3rd Person View)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 2,
+                "actionmap": "vehicle_general",
+                "action": "v_view_zoom_out"
+            },
+            {
+                "name": "Look Left/Right",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 4,
+                "actionmap": "vehicle_general",
+                "action": "v_view_yaw"
+            },
+            {
+                "name": "Look Up/Down",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 5,
+                "actionmap": "vehicle_general",
+                "action": "v_view_pitch"
+            },
+            {
+                "name": "Freelook (Hold)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 5,
+                "button": 3,
+                "actionmap": "vehicle_general",
+                "action": "v_view_freelook_mode"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_all"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_group1"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_group2"
+            },
+            {
+                "name": "Flight/Systems Ready",
+                "id": 60,
+                "type": "button",
+                "vjoy": 5,
+                "button": 4,
+                "actionmap": "vehicle_general",
+                "action": "v_flightready"
+            },
+            {
+                "name": "Open/Close Doors Toggle",
+                "id": 65,
+                "type": "button",
+                "vjoy": 5,
+                "button": 5,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_doors"
+            },
+            {
+                "name": "Open All Doors",
+                "id": 70,
+                "type": "button",
+                "vjoy": 5,
+                "button": 6,
+                "actionmap": "vehicle_general",
+                "action": "v_open_all_doors"
+            },
+            {
+                "name": "Close All Doors",
+                "id": 75,
+                "type": "button",
+                "vjoy": 5,
+                "button": 7,
+                "actionmap": "vehicle_general",
+                "action": "v_close_all_doors"
+            },
+            {
+                "name": "Lock/Unlock Doors Toggle",
+                "id": 80,
+                "type": "button",
+                "vjoy": 5,
+                "button": 8,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_doorlocks"
+            },
+            {
+                "name": "Lock All Doors",
+                "id": 85,
+                "type": "button",
+                "vjoy": 5,
+                "button": 9,
+                "actionmap": "vehicle_general",
+                "action": "v_lock_all_doors"
+            },
+            {
+                "name": "Unlock All Doors",
+                "id": 90,
+                "type": "button",
+                "vjoy": 5,
+                "button": 10,
+                "actionmap": "vehicle_general",
+                "action": "v_unlock_all_doors"
+            },
+            {
+                "name": "Port Lock Toggle All",
+                "id": 95,
+                "type": "button",
+                "vjoy": 5,
+                "button": 11,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_portlocks"
+            },
+            {
+                "name": "Port Lock All",
+                "id": 100,
+                "type": "button",
+                "vjoy": 5,
+                "button": 12,
+                "actionmap": "vehicle_general",
+                "action": "v_lock_all_ports"
+            },
+            {
+                "name": "Port Unlock All",
+                "id": 105,
+                "type": "button",
+                "vjoy": 5,
+                "button": 13,
+                "actionmap": "vehicle_general",
+                "action": "v_unlock_all_ports"
+            },
+            {
+                "name": "Map",
+                "id": 110,
+                "type": "button",
+                "vjoy": 5,
+                "button": 14,
+                "actionmap": "vehicle_general",
+                "action": "v_starmap"
+            },
+            {
+                "name": "Wipe Helmet Visor",
+                "id": 115,
+                "type": "button",
+                "vjoy": 5,
+                "button": 15,
+                "actionmap": "vehicle_general",
+                "action": "visor_wipe"
+            }
+        ]
+    },
+    {
+        "category_id": 125,
+        "name": "Ground Vehicle - Movement",
+        "values": [
+            {
+                "name": "Drive Forward",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 16,
+                "actionmap": "vehicle_driver",
+                "action": "v_move_forward"
+            },
+            {
+                "name": "Drive Backward",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 17,
+                "actionmap": "vehicle_driver",
+                "action": "v_move_back"
+            },
+            {
+                "name": "Drive Forward/Backward",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 6,
+                "actionmap": "vehicle_driver",
+                "action": "v_move"
+            },
+            {
+                "name": "Turn Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 18,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw_left"
+            },
+            {
+                "name": "Turn Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 5,
+                "button": 19,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw_right"
+            },
+            {
+                "name": "Turn Left/Right",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 7,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw"
+            },
+            {
+                "name": "Pitch Up",
+                "id": 40,
+                "type": "button",
+                "vjoy": 5,
+                "button": 20,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 45,
+                "type": "button",
+                "vjoy": 5,
+                "button": 21,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch_down"
+            },
+            {
+                "name": "Pitch Up/Down",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 8,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch"
+            },
+            {
+                "name": "Brake",
+                "id": 55,
+                "type": "button",
+                "vjoy": 5,
+                "button": 22,
+                "actionmap": "vehicle_driver",
+                "action": "v_brake"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (relative)",
+                "id": 60,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 1,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel"
+            },
+            {
+                "name": "Dynamic Zoom In (relative)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 5,
+                "button": 23,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel_in"
+            },
+            {
+                "name": "Dynamic Zoom Out (relative)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 5,
+                "button": 24,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel_out"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (absolute)",
+                "id": 75,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 2,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_abs"
+            },
+            {
+                "name": "Dynamic Zoom Toggle (absolute)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 5,
+                "button": 25,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_abs_toggle"
+            },
+            {
+                "name": "Boost",
+                "id": 85,
+                "type": "button",
+                "vjoy": 5,
+                "button": 26,
+                "actionmap": "vehicle_driver",
+                "action": "v_boost"
+            },
+            {
+                "name": "Lock Pitch/Yaw Movement (toggle/hold)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 5,
+                "button": 27,
+                "actionmap": "vehicle_driver",
+                "action": "v_lock_rotation"
+            },
+            {
+                "name": "Toggle Brake on Idle",
+                "id": 95,
+                "type": "button",
+                "vjoy": 5,
+                "button": 28,
+                "actionmap": "vehicle_driver",
+                "action": "v_mgv_switch_brake_on_idle"
+            }
+        ]
+    },
+    {
+        "category_id": 130,
+        "name": "Electronic Access - Spectator",
+        "values": [
+            {
+                "name": "Spectator Camera Next Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 29,
+                "actionmap": "spectator",
+                "action": "spectate_next_target"
+            },
+            {
+                "name": "Spectator Camera Previous Target",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 30,
+                "actionmap": "spectator",
+                "action": "spectate_prev_target"
+            },
+            {
+                "name": "Spectator Camera Lock Target",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 31,
+                "actionmap": "spectator",
+                "action": "spectate_toggle_lock_target"
+            },
+            {
+                "name": "Spectator Camera Zoom",
+                "id": 25,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 3,
+                "actionmap": "spectator",
+                "action": "spectate_zoom"
+            },
+            {
+                "name": "Spectator Camera Zoom In",
+                "id": 30,
+                "type": "button",
+                "vjoy": 5,
+                "button": 32,
+                "actionmap": "spectator",
+                "action": "spectate_zoom_in"
+            },
+            {
+                "name": "Spectator Camera Zoom Out",
+                "id": 35,
+                "type": "button",
+                "vjoy": 5,
+                "button": 33,
+                "actionmap": "spectator",
+                "action": "spectate_zoom_out"
+            },
+            {
+                "name": "Spectator Camera Rotate Yaw",
+                "id": 40,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 4,
+                "actionmap": "spectator",
+                "action": "spectate_rotateyaw"
+            },
+            {
+                "name": "Spectator Camera Rotate Pitch",
+                "id": 45,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 5,
+                "actionmap": "spectator",
+                "action": "spectate_rotatepitch"
+            },
+            {
+                "name": "Spectator Camera Rotate Yaw (Mouse)",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 6,
+                "actionmap": "spectator",
+                "action": "spectate_rotateyaw_mouse"
+            },
+            {
+                "name": "Spectator Camera Rotate Pitch (Mouse)",
+                "id": 55,
+                "type": "axis",
+                "vjoy": 6,
+                "axis": 7,
+                "actionmap": "spectator",
+                "action": "spectate_rotatepitch_mouse"
+            },
+            {
+                "name": "Spectator Camera HUD (toggle)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 5,
+                "button": 34,
+                "actionmap": "spectator",
+                "action": "spectate_toggle_hud"
+            },
+            {
+                "name": "Spectator Camera Mode - Next",
+                "id": 65,
+                "type": "button",
+                "vjoy": 5,
+                "button": 35,
+                "actionmap": "spectator",
+                "action": "spectate_gen_nextmode"
+            },
+            {
+                "name": "Spectator Camera Mode - Previous",
+                "id": 70,
+                "type": "button",
+                "vjoy": 5,
+                "button": 36,
+                "actionmap": "spectator",
+                "action": "spectate_gen_prevmode"
+            }
+        ]
+    },
+    {
+        "category_id": 135,
+        "name": "Social - General",
+        "values": [
+            {
+                "name": "Re-Spawn",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 37,
+                "actionmap": "default",
+                "action": "respawn"
+            },
+            {
+                "name": "Exit Seat",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 38,
+                "actionmap": "default",
+                "action": "pl_exit"
+            },
+            {
+                "name": "Notification Accept",
+                "id": 17,
+                "type": "button",
+                "vjoy": 5,
+                "button": 39,
+                "actionmap": "default",
+                "action": "notification_accept"
+            },
+            {
+                "name": "Notification Decline",
+                "id": 18,
+                "type": "button",
+                "vjoy": 5,
+                "button": 40,
+                "actionmap": "default",
+                "action": "notification_decline"
+            },
+            {
+                "name": "CommLink App",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 41,
+                "actionmap": "default",
+                "action": "toggle_contact"
+            },
+            {
+                "name": "Chat Window",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 42,
+                "actionmap": "default",
+                "action": "toggle_chat"
+            },
+            {
+                "name": "Chat Window Focus",
+                "id": 30,
+                "type": "button",
+                "vjoy": 5,
+                "button": 43,
+                "actionmap": "default",
+                "action": "focus_on_chat_textinput"
+            },
+            {
+                "name": "Chat Cycle Lobby",
+                "id": 35,
+                "type": "button",
+                "vjoy": 5,
+                "button": 44,
+                "actionmap": "default",
+                "action": "cycle_chat_lobby"
+            }
+        ]
+    },
+    {
+        "category_id": 140,
+        "name": "VOIP, FOIP and Head Tracking",
+        "values": [
+            {
+                "name": "VR - Toggle On/Off",
+                "id": 1,
+                "type": "button",
+                "vjoy": 5,
+                "button": 45,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_toggle"
+            },
+            {
+                "name": "VR - Recenter Device",
+                "id": 2,
+                "type": "button",
+                "vjoy": 5,
+                "button": 46,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_recenter"
+            },
+            {
+                "name": "VR - Toggle Theater Mode",
+                "id": 5,
+                "type": "button",
+                "vjoy": 5,
+                "button": 47,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_theater_mode_toggle"
+            },
+            {
+                "name": "VR - Toggle Visor On/Off",
+                "id": 6,
+                "type": "button",
+                "vjoy": 5,
+                "button": 48,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_lens_display_toggle"
+            },
+            {
+                "name": "Enable Head Tracking (toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 49,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_enabled"
+            },
+            {
+                "name": "Head Tracking (hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 50,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_hold"
+            },
+            {
+                "name": "Recenter Head Tracking Device (except TrackIR)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 51,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_recenter_device"
+            },
+            {
+                "name": "Enable/Disable Head Tracking for 3rd Person Camera",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 52,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_camera_enabled"
+            },
+            {
+                "name": "VOIP Push to Talk",
+                "id": 30,
+                "type": "button",
+                "vjoy": 5,
+                "button": 53,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_pushtotalk"
+            },
+            {
+                "name": "VOIP Push to Talk (Proximity Only)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 5,
+                "button": 54,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_pushtotalk_proximity"
+            },
+            {
+                "name": "FOIP Selfie Cam",
+                "id": 40,
+                "type": "button",
+                "vjoy": 5,
+                "button": 55,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_viewownplayer"
+            },
+            {
+                "name": "FOIP Recalibrate",
+                "id": 45,
+                "type": "button",
+                "vjoy": 5,
+                "button": 56,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_recalibrate"
+            },
+            {
+                "name": "Cycle through Audio Channels",
+                "id": 50,
+                "type": "button",
+                "vjoy": 5,
+                "button": 57,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_cyclechannel"
+            }
+        ]
+    },
+    {
+        "category_id": 150,
+        "name": "Quick Keys, Interactions and Inner Thoughts",
+        "values": [
+            {
+                "name": "Focus",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 58,
+                "actionmap": "player_choice",
+                "action": "pc_focus"
+            },
+            {
+                "name": "Interaction Mode",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 59,
+                "actionmap": "player_choice",
+                "action": "pc_interaction_mode"
+            },
+            {
+                "name": "Interaction Select",
+                "id": 16,
+                "type": "button",
+                "vjoy": 5,
+                "button": 60,
+                "actionmap": "player_choice",
+                "action": "pc_interaction_select"
+            },
+            {
+                "name": "Activate Inner Thought",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 61,
+                "actionmap": "player_choice",
+                "action": "pc_select"
+            },
+            {
+                "name": "Interaction Mode Zoom In",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 62,
+                "actionmap": "player_choice",
+                "action": "pc_zoom_in"
+            },
+            {
+                "name": "Interaction Mode Zoom Out",
+                "id": 30,
+                "type": "button",
+                "vjoy": 5,
+                "button": 63,
+                "actionmap": "player_choice",
+                "action": "pc_zoom_out"
+            },
+            {
+                "name": "MFD Left",
+                "id": 35,
+                "type": "button",
+                "vjoy": 5,
+                "button": 64,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_left"
+            },
+            {
+                "name": "MFD Right",
+                "id": 40,
+                "type": "button",
+                "vjoy": 5,
+                "button": 65,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_right"
+            },
+            {
+                "name": "MFD Up",
+                "id": 45,
+                "type": "button",
+                "vjoy": 5,
+                "button": 66,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_up"
+            },
+            {
+                "name": "MFD Down",
+                "id": 50,
+                "type": "button",
+                "vjoy": 5,
+                "button": 67,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_down"
+            },
+            {
+                "name": "Exit",
+                "id": 55,
+                "type": "button",
+                "vjoy": 5,
+                "button": 68,
+                "actionmap": "player_choice",
+                "action": "pc_personal_back"
+            }
+        ]
+    },
+    {
+        "category_id": 160,
+        "name": "Camera - Advanced Camera Controls",
+        "values": [
+            {
+                "name": "Increase FOV",
+                "id": 10,
+                "type": "button",
+                "vjoy": 5,
+                "button": 69,
+                "actionmap": "view_director_mode",
+                "action": "view_fov_in"
+            },
+            {
+                "name": "Decrease FOV",
+                "id": 15,
+                "type": "button",
+                "vjoy": 5,
+                "button": 70,
+                "actionmap": "view_director_mode",
+                "action": "view_fov_out"
+            },
+            {
+                "name": "Increase DoF",
+                "id": 16,
+                "type": "button",
+                "vjoy": 5,
+                "button": 71,
+                "actionmap": "view_director_mode",
+                "action": "view_fstop_in"
+            },
+            {
+                "name": "Decrease DoF",
+                "id": 20,
+                "type": "button",
+                "vjoy": 5,
+                "button": 72,
+                "actionmap": "view_director_mode",
+                "action": "view_fstop_out"
+            },
+            {
+                "name": "Reset Current View",
+                "id": 25,
+                "type": "button",
+                "vjoy": 5,
+                "button": 73,
+                "actionmap": "view_director_mode",
+                "action": "view_restore_defaults"
+            }
+        ]
+    }
+]

--- a/controls_mappings/StarCitizenControlsMapping-4.6.x.json
+++ b/controls_mappings/StarCitizenControlsMapping-4.6.x.json
@@ -1,0 +1,5554 @@
+[
+    {
+        "category_id": 10,
+        "name": "Vehicles - Seats and Operator Modes",
+        "values": [
+            {
+                "name": "Emergency Exit Seat",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 1,
+                "actionmap": "seat_general",
+                "action": "v_emergency_exit"
+            },
+            {
+                "name": "Eject",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 2,
+                "actionmap": "seat_general",
+                "action": "v_eject"
+            },
+            {
+                "name": "Look Behind",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 3,
+                "actionmap": "seat_general",
+                "action": "v_view_look_behind"
+            },
+            {
+                "name": "Toggle Mining Operator Mode",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 4,
+                "actionmap": "seat_general",
+                "action": "v_toggle_mining_mode"
+            },
+            {
+                "name": "Toggle Salvage Operator Mode",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 5,
+                "actionmap": "seat_general",
+                "action": "v_toggle_salvage_mode"
+            },
+            {
+                "name": "Toggle Scanning Operator Mode",
+                "id": 33,
+                "type": "button",
+                "vjoy": 1,
+                "button": 6,
+                "actionmap": "seat_general",
+                "action": "v_toggle_scan_mode"
+            },
+            {
+                "name": "Toggle Quantum Operator Mode",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 7,
+                "actionmap": "seat_general",
+                "action": "v_toggle_quantum_mode"
+            },
+            {
+                "name": "Toggle Missile Operator Mode",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 8,
+                "actionmap": "seat_general",
+                "action": "v_toggle_missile_mode"
+            },
+            {
+                "name": "Toggle Guns Operator Mode",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 9,
+                "actionmap": "seat_general",
+                "action": "v_toggle_guns_mode"
+            },
+            {
+                "name": "Toggle Flight Operator Mode",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 10,
+                "actionmap": "seat_general",
+                "action": "v_toggle_flight_mode"
+            },
+            {
+                "name": "Set Mining Operator Mode",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 11,
+                "actionmap": "seat_general",
+                "action": "v_set_mining_mode"
+            },
+            {
+                "name": "Set Salvage Operator Mode",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 12,
+                "actionmap": "seat_general",
+                "action": "v_set_salvage_mode"
+            },
+            {
+                "name": "Set Scanning Operator Mode",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 13,
+                "actionmap": "seat_general",
+                "action": "v_set_scan_mode"
+            },
+            {
+                "name": "Set Quantum Operator Mode",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 14,
+                "actionmap": "seat_general",
+                "action": "v_set_quantum_mode"
+            },
+            {
+                "name": "Set Missile Operator Mode",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 15,
+                "actionmap": "seat_general",
+                "action": "v_set_missile_mode"
+            },
+            {
+                "name": "Set Guns Operator Mode",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 16,
+                "actionmap": "seat_general",
+                "action": "v_set_guns_mode"
+            },
+            {
+                "name": "Set Flight Operator Mode",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 17,
+                "actionmap": "seat_general",
+                "action": "v_set_flight_mode"
+            },
+            {
+                "name": "Next Operator Mode",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 18,
+                "actionmap": "seat_general",
+                "action": "v_operator_mode_cycle_forward"
+            },
+            {
+                "name": "Previous Operator Mode",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 19,
+                "actionmap": "seat_general",
+                "action": "v_operator_mode_cycle_back"
+            },
+            {
+                "name": "Enter Remote Turret 1",
+                "id": 110,
+                "type": "button",
+                "vjoy": 1,
+                "button": 20,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_1"
+            },
+            {
+                "name": "Enter Remote Turret 2",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 21,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_2"
+            },
+            {
+                "name": "Enter Remote Turret 3",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 22,
+                "actionmap": "seat_general",
+                "action": "v_enter_remote_turret_3"
+            },
+            {
+                "name": "Light Amplificaton Toggle",
+                "id": 125,
+                "type": "button",
+                "vjoy": 1,
+                "button": 23,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_toggle"
+            },
+            {
+                "name": "Light Amplificaton On",
+                "id": 130,
+                "type": "button",
+                "vjoy": 1,
+                "button": 24,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_on"
+            },
+            {
+                "name": "Light Amplificaton Off",
+                "id": 135,
+                "type": "button",
+                "vjoy": 1,
+                "button": 25,
+                "actionmap": "seat_general",
+                "action": "v_light_amplification_off"
+            }
+        ]
+    },
+    {
+        "category_id": 15,
+        "name": "Vehicles - Cockpit",
+        "values": [
+            {
+                "name": "Self Destruct",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 26,
+                "actionmap": "spaceship_general",
+                "action": "v_self_destruct"
+            },
+            {
+                "name": "Increase Cooler Rate",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 27,
+                "actionmap": "spaceship_general",
+                "action": "v_cooler_throttle_up"
+            },
+            {
+                "name": "Decrease Cooler Rate",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 28,
+                "actionmap": "spaceship_general",
+                "action": "v_cooler_throttle_down"
+            },
+            {
+                "name": "Flight/Systems Ready",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 29,
+                "actionmap": "spaceship_general",
+                "action": "v_flightready"
+            },
+            {
+                "name": "Open/Close Doors Toggle",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 30,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_doors"
+            },
+            {
+                "name": "Open All Doors",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 31,
+                "actionmap": "spaceship_general",
+                "action": "v_open_all_doors"
+            },
+            {
+                "name": "Close All Doors",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 32,
+                "actionmap": "spaceship_general",
+                "action": "v_close_all_doors"
+            },
+            {
+                "name": "Lock/Unlock Doors Toggle",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 33,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_doorlocks"
+            },
+            {
+                "name": "Lock All Doors",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 34,
+                "actionmap": "spaceship_general",
+                "action": "v_lock_all_doors"
+            },
+            {
+                "name": "Unlock All Doors",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 35,
+                "actionmap": "spaceship_general",
+                "action": "v_unlock_all_doors"
+            },
+            {
+                "name": "Port Lock Toggle All",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 36,
+                "actionmap": "spaceship_general",
+                "action": "v_toggle_all_portlocks"
+            },
+            {
+                "name": "Port Lock All",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 37,
+                "actionmap": "spaceship_general",
+                "action": "v_lock_all_ports"
+            },
+            {
+                "name": "Port Unlock All",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 38,
+                "actionmap": "spaceship_general",
+                "action": "v_unlock_all_ports"
+            }
+        ]
+    },
+    {
+        "category_id": 18,
+        "name": "Vehicles - Multi Function Displays (MFDs)",
+        "values": [
+            {
+                "name": "MFD - Cycle Page - Forwards (short)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 39,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_forwards_short"
+            },
+            {
+                "name": "MFD - Cycle Page - Forwards (long)",
+                "id": 11,
+                "type": "button",
+                "vjoy": 1,
+                "button": 40,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_forwards_long"
+            },
+            {
+                "name": "MFD - Cycle Page - Backwards (short)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 41,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_backwards_short"
+            },
+            {
+                "name": "MFD - Cycle Page - Backwards (long)",
+                "id": 16,
+                "type": "button",
+                "vjoy": 1,
+                "button": 42,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_interact_cycle_backwards_long"
+            },
+            {
+                "name": "MFD - Movement - Up (short)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 1,
+                "button": 43,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_up_short"
+            },
+            {
+                "name": "MFD - Movement - Up (long)",
+                "id": 21,
+                "type": "button",
+                "vjoy": 1,
+                "button": 44,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_up_long"
+            },
+            {
+                "name": "MFD - Movement - Down (short)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 45,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_down_short"
+            },
+            {
+                "name": "MFD - Movement - Down (long)",
+                "id": 26,
+                "type": "button",
+                "vjoy": 1,
+                "button": 46,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_down_long"
+            },
+            {
+                "name": "MFD - Movement - Left (short)",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 47,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_left_short"
+            },
+            {
+                "name": "MFD - Movement - Left (long)",
+                "id": 31,
+                "type": "button",
+                "vjoy": 1,
+                "button": 48,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_left_long"
+            },
+            {
+                "name": "MFD - Movement - Right (short)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 1,
+                "button": 49,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_right_short"
+            },
+            {
+                "name": "MFD - Movement - Right (long)",
+                "id": 36,
+                "type": "button",
+                "vjoy": 1,
+                "button": 50,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_movement_right_long"
+            },
+            {
+                "name": "MFD - Select - Primary (short)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 51,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_primary_short"
+            },
+            {
+                "name": "MFD - Select - Primary (long)",
+                "id": 41,
+                "type": "button",
+                "vjoy": 1,
+                "button": 52,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_primary_long"
+            },
+            {
+                "name": "MFD - Select - Left Cast (short)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 53,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_left_short"
+            },
+            {
+                "name": "MFD - Select - Left Cast (long)",
+                "id": 46,
+                "type": "button",
+                "vjoy": 1,
+                "button": 54,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_left_long"
+            },
+            {
+                "name": "MFD - Select - Right Cast (short)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 55,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_right_short"
+            },
+            {
+                "name": "MFD - Select - Right Cast (long)",
+                "id": 51,
+                "type": "button",
+                "vjoy": 1,
+                "button": 56,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_cast_right_long"
+            },
+            {
+                "name": "MFD - Select - MFD 1 (short)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 57,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_1_short"
+            },
+            {
+                "name": "MFD - Select - MFD 1 (long)",
+                "id": 56,
+                "type": "button",
+                "vjoy": 1,
+                "button": 58,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_1_long"
+            },
+            {
+                "name": "MFD - Select - MFD 2 (short)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 59,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_2_short"
+            },
+            {
+                "name": "MFD - Select - MFD 2 (long)",
+                "id": 61,
+                "type": "button",
+                "vjoy": 1,
+                "button": 60,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_2_long"
+            },
+            {
+                "name": "MFD - Select - MFD 3 (short)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 61,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_3_short"
+            },
+            {
+                "name": "MFD - Select - MFD 3 (long)",
+                "id": 66,
+                "type": "button",
+                "vjoy": 1,
+                "button": 62,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_3_long"
+            },
+            {
+                "name": "MFD - Select - MFD 4 (short)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 63,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_4_short"
+            },
+            {
+                "name": "MFD - Select - MFD 4 (long)",
+                "id": 71,
+                "type": "button",
+                "vjoy": 1,
+                "button": 64,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_4_long"
+            },
+            {
+                "name": "MFD - Select - MFD 5 (short)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 65,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_5_short"
+            },
+            {
+                "name": "MFD - Select - MFD 5 (long)",
+                "id": 76,
+                "type": "button",
+                "vjoy": 1,
+                "button": 66,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_5_long"
+            },
+            {
+                "name": "MFD - Select - MFD 6 (short)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 67,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_6_short"
+            },
+            {
+                "name": "MFD - Select - MFD 6 (long)",
+                "id": 81,
+                "type": "button",
+                "vjoy": 1,
+                "button": 68,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_6_long"
+            },
+            {
+                "name": "MFD - Select - MFD 7 (short)",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 69,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_7_short"
+            },
+            {
+                "name": "MFD - Select - MFD 7 (long)",
+                "id": 86,
+                "type": "button",
+                "vjoy": 1,
+                "button": 70,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_7_long"
+            },
+            {
+                "name": "MFD - Select - MFD 8 (short)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 71,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_8_short"
+            },
+            {
+                "name": "MFD - Select - MFD 8 (long)",
+                "id": 91,
+                "type": "button",
+                "vjoy": 1,
+                "button": 72,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_8_long"
+            },
+            {
+                "name": "MFD - Select - MFD 9 (short)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 1,
+                "button": 73,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_9_short"
+            },
+            {
+                "name": "MFD - Select - MFD 9 (long)",
+                "id": 96,
+                "type": "button",
+                "vjoy": 1,
+                "button": 74,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_9_long"
+            },
+            {
+                "name": "MFD - Select - MFD 10 (short)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 75,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_10_short"
+            },
+            {
+                "name": "MFD - Select - MFD 10 (long)",
+                "id": 101,
+                "type": "button",
+                "vjoy": 1,
+                "button": 76,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_soft_select_mfd_10_long"
+            },
+            {
+                "name": "MFD - Quick Action - Self Repair All",
+                "id": 102,
+                "type": "button",
+                "vjoy": 1,
+                "button": 77,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_quick_action_repair_all"
+            },
+            {
+                "name": "MFD - Set Page - Self Status (short)",
+                "id": 103,
+                "type": "button",
+                "vjoy": 1,
+                "button": 78,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_self_status_short"
+            },
+            {
+                "name": "MFD - Set Page - Self Status (long)",
+                "id": 104,
+                "type": "button",
+                "vjoy": 1,
+                "button": 79,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_self_status_long"
+            },
+            {
+                "name": "MFD - Set Page - Target Status (short)",
+                "id": 105,
+                "type": "button",
+                "vjoy": 1,
+                "button": 80,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_target_status_short"
+            },
+            {
+                "name": "MFD - Set Page - Target Status (long)",
+                "id": 106,
+                "type": "button",
+                "vjoy": 1,
+                "button": 81,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_target_status_long"
+            },
+            {
+                "name": "MFD - Set Page - Scanning (short)",
+                "id": 110,
+                "type": "button",
+                "vjoy": 1,
+                "button": 82,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_scanning_short"
+            },
+            {
+                "name": "MFD - Set Page - Scanning (long)",
+                "id": 111,
+                "type": "button",
+                "vjoy": 1,
+                "button": 83,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_scanning_long"
+            },
+            {
+                "name": "MFD - Set Page - Vehicle Config (short)",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 84,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_configuration_short"
+            },
+            {
+                "name": "MFD - Set Page - Vehicle Config (long)",
+                "id": 116,
+                "type": "button",
+                "vjoy": 1,
+                "button": 85,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_configuration_long"
+            },
+            {
+                "name": "MFD - Set Page - Comms (short)",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 86,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_comms_short"
+            },
+            {
+                "name": "MFD - Set Page - Comms (long)",
+                "id": 121,
+                "type": "button",
+                "vjoy": 1,
+                "button": 87,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_comms_long"
+            },
+            {
+                "name": "MFD - Set Page - IFCS (short)",
+                "id": 125,
+                "type": "button",
+                "vjoy": 1,
+                "button": 88,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_ifcs_short"
+            },
+            {
+                "name": "MFD - Set Page - IFCS (long)",
+                "id": 126,
+                "type": "button",
+                "vjoy": 1,
+                "button": 89,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_ifcs_long"
+            },
+            {
+                "name": "MFD - Set Page - Diagnostics (short)",
+                "id": 130,
+                "type": "button",
+                "vjoy": 1,
+                "button": 90,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_diagnostics_short"
+            },
+            {
+                "name": "MFD - Set Page - Diagnostics (long)",
+                "id": 131,
+                "type": "button",
+                "vjoy": 1,
+                "button": 91,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_diagnostics_long"
+            },
+            {
+                "name": "MFD - Set Page - Resource Network (short)",
+                "id": 135,
+                "type": "button",
+                "vjoy": 1,
+                "button": 92,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_resource_network_short"
+            },
+            {
+                "name": "MFD - Set Page - Resource Network (long)",
+                "id": 136,
+                "type": "button",
+                "vjoy": 1,
+                "button": 93,
+                "actionmap": "vehicle_mfd",
+                "action": "v_mfd_select_view_resource_network_long"
+            }
+        ]
+    },
+    {
+        "category_id": 20,
+        "name": "Vehicles - View",
+        "values": [
+            {
+                "name": "Look Left",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 94,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw_left"
+            },
+            {
+                "name": "Look Right",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 95,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw_right"
+            },
+            {
+                "name": "Look Left/Right",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 1,
+                "actionmap": "spaceship_view",
+                "action": "v_view_yaw"
+            },
+            {
+                "name": "Look Up",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 96,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch_up"
+            },
+            {
+                "name": "Look Down",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 97,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch_down"
+            },
+            {
+                "name": "Look Up/Down",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 2,
+                "actionmap": "spaceship_view",
+                "action": "v_view_pitch"
+            },
+            {
+                "name": "Cycle Camera View",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 98,
+                "actionmap": "spaceship_view",
+                "action": "v_view_cycle_fwd"
+            },
+            {
+                "name": "Cycle Camera Orbit Mode",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 99,
+                "actionmap": "spaceship_view",
+                "action": "v_view_mode"
+            },
+            {
+                "name": "Zoom In (3rd Person View)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 1,
+                "button": 100,
+                "actionmap": "spaceship_view",
+                "action": "v_view_zoom_in"
+            },
+            {
+                "name": "Zoom Out (3rd Person View)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 101,
+                "actionmap": "spaceship_view",
+                "action": "v_view_zoom_out"
+            },
+            {
+                "name": "Freelook (Hold)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 102,
+                "actionmap": "spaceship_view",
+                "action": "v_view_freelook_mode"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (relative)",
+                "id": 65,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 3,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel"
+            },
+            {
+                "name": "Dynamic Zoom In (relative)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 1,
+                "button": 103,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel_in"
+            },
+            {
+                "name": "Dynamic Zoom Out (relative)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 104,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_rel_out"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (absolute)",
+                "id": 80,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 4,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_abs"
+            },
+            {
+                "name": "Dynamic Zoom Toggle (absolute)",
+                "id": 85,
+                "type": "button",
+                "vjoy": 1,
+                "button": 105,
+                "actionmap": "spaceship_view",
+                "action": "v_view_dynamic_zoom_abs_toggle"
+            },
+            {
+                "name": "Precision Targeting - Enable (Hold)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 106,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_hold"
+            },
+            {
+                "name": "Precision Targeting - Toggle",
+                "id": 95,
+                "type": "button",
+                "vjoy": 1,
+                "button": 107,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_toggle"
+            },
+            {
+                "name": "Precision Targeting - Max Zoom (Hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 1,
+                "button": 108,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_stable_max_zoom_hold"
+            },
+            {
+                "name": "Precision Targeting - Toggle Camera Tracking",
+                "id": 105,
+                "type": "button",
+                "vjoy": 1,
+                "button": 109,
+                "actionmap": "spaceship_view",
+                "action": "v_ads_cycle_tracking"
+            }
+        ]
+    },
+    {
+        "category_id": 25,
+        "name": "Flight - Movement",
+        "values": [
+            {
+                "name": "Pitch Up",
+                "id": 10,
+                "type": "button",
+                "vjoy": 1,
+                "button": 110,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 15,
+                "type": "button",
+                "vjoy": 1,
+                "button": 111,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch_down"
+            },
+            {
+                "name": "Pitch",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_pitch"
+            },
+            {
+                "name": "Yaw Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 1,
+                "button": 112,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw_left"
+            },
+            {
+                "name": "Yaw Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 1,
+                "button": 113,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw_right"
+            },
+            {
+                "name": "Yaw",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_yaw"
+            },
+            {
+                "name": "Roll Left",
+                "id": 40,
+                "type": "button",
+                "vjoy": 1,
+                "button": 114,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll_left"
+            },
+            {
+                "name": "Roll Right",
+                "id": 45,
+                "type": "button",
+                "vjoy": 1,
+                "button": 115,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll_right"
+            },
+            {
+                "name": "Roll",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 7,
+                "actionmap": "spaceship_movement",
+                "action": "v_roll"
+            },
+            {
+                "name": "Swap Yaw/Roll",
+                "id": 55,
+                "type": "button",
+                "vjoy": 1,
+                "button": 116,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_yaw_roll_swap"
+            },
+            {
+                "name": "Strafe Up (absolute)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 1,
+                "button": 117,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_up"
+            },
+            {
+                "name": "Strafe Down (absolute)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 1,
+                "button": 118,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_down"
+            },
+            {
+                "name": "Strafe Up/Down (absolute)",
+                "id": 70,
+                "type": "axis",
+                "vjoy": 1,
+                "axis": 8,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_vertical"
+            },
+            {
+                "name": "Strafe Left (absolute)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 1,
+                "button": 119,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_left"
+            },
+            {
+                "name": "Strafe Right (absolute)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 1,
+                "button": 120,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_right"
+            },
+            {
+                "name": "Strafe Left/Right (absolute)",
+                "id": 85,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 1,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_lateral"
+            },
+            {
+                "name": "Throttle Forward/Backward Invert",
+                "id": 90,
+                "type": "button",
+                "vjoy": 1,
+                "button": 121,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_longitudinal_invert"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 95,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 100,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 105,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 110,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Throttle - Increase",
+                "id": 115,
+                "type": "button",
+                "vjoy": 1,
+                "button": 122,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_forward"
+            },
+            {
+                "name": "Throttle - Decrease",
+                "id": 120,
+                "type": "button",
+                "vjoy": 1,
+                "button": 123,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_back"
+            },
+            {
+                "name": "Throttle - Forward / Backward",
+                "id": 125,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 2,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_longitudinal"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 130,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 135,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 140,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Throttle - Cruise Mode - Toggle",
+                "id": 142,
+                "type": "button",
+                "vjoy": 1,
+                "button": 124,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_swap_mode"
+            },
+            {
+                "name": "Throttle - Cruise Mode - Enable",
+                "id": 143,
+                "type": "button",
+                "vjoy": 1,
+                "button": 125,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_set_sticky"
+            },
+            {
+                "name": "Throttle - Cruise Mode - Disable",
+                "id": 144,
+                "type": "button",
+                "vjoy": 1,
+                "button": 126,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_throttle_set_normal"
+            },
+            {
+                "name": "Throttle - Trim - Set (long)",
+                "id": 145,
+                "type": "button",
+                "vjoy": 1,
+                "button": 127,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_long"
+            },
+            {
+                "name": "Throttle - Trim - Set (short)",
+                "id": 150,
+                "type": "button",
+                "vjoy": 1,
+                "button": 128,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_short"
+            },
+            {
+                "name": "Throttle - Trim - Set to 100% (long)",
+                "id": 152,
+                "type": "button",
+                "vjoy": 2,
+                "button": 1,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_100_long"
+            },
+            {
+                "name": "Throttle - Trim - Set to 100% (short)",
+                "id": 154,
+                "type": "button",
+                "vjoy": 2,
+                "button": 2,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_100_short"
+            },
+            {
+                "name": "Throttle - Trim - Set to 50% (long)",
+                "id": 156,
+                "type": "button",
+                "vjoy": 2,
+                "button": 3,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_50_long"
+            },
+            {
+                "name": "Throttle - Trim - Set to 50% (short)",
+                "id": 158,
+                "type": "button",
+                "vjoy": 2,
+                "button": 4,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_set_50_short"
+            },
+            {
+                "name": "Throttle - Trim - Release (long)",
+                "id": 160,
+                "type": "button",
+                "vjoy": 2,
+                "button": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_reset_long"
+            },
+            {
+                "name": "Throttle - Trim - Release (short)",
+                "id": 161,
+                "type": "button",
+                "vjoy": 2,
+                "button": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_strafe_trim_reset_short"
+            },
+            {
+                "name": "Enable/Disable Decoupled Mode",
+                "id": 165,
+                "type": "button",
+                "vjoy": 2,
+                "button": 7,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_toggle"
+            },
+            {
+                "name": "Enable Decoupled Mode",
+                "id": 166,
+                "type": "button",
+                "vjoy": 2,
+                "button": 8,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_on"
+            },
+            {
+                "name": "Disable Decoupled Mode",
+                "id": 167,
+                "type": "button",
+                "vjoy": 2,
+                "button": 9,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_vector_decoupling_off"
+            },
+            {
+                "name": "Boost",
+                "id": 170,
+                "type": "button",
+                "vjoy": 2,
+                "button": 10,
+                "actionmap": "spaceship_movement",
+                "action": "v_afterburner"
+            },
+            {
+                "name": "Speed Limiter - Increase",
+                "id": 175,
+                "type": "button",
+                "vjoy": 2,
+                "button": 11,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_up"
+            },
+            {
+                "name": "Speed Limiter - Decrease",
+                "id": 180,
+                "type": "button",
+                "vjoy": 2,
+                "button": 12,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_down"
+            },
+            {
+                "name": "Speed Limiter - Step Up",
+                "id": 182,
+                "type": "button",
+                "vjoy": 2,
+                "button": 13,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_decrement"
+            },
+            {
+                "name": "Speed Limiter - Step Down",
+                "id": 183,
+                "type": "button",
+                "vjoy": 2,
+                "button": 14,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_increment"
+            },
+            {
+                "name": "Speed Limiter (relative)",
+                "id": 185,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 3,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_rel"
+            },
+            {
+                "name": "Speed Limiter (absolute)",
+                "id": 190,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 4,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_abs"
+            },
+            {
+                "name": "Speed Limiter - Enable / Disable",
+                "id": 195,
+                "type": "button",
+                "vjoy": 2,
+                "button": 15,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_toggle"
+            },
+            {
+                "name": "Speed Limiter - Enable",
+                "id": 196,
+                "type": "button",
+                "vjoy": 2,
+                "button": 16,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_on"
+            },
+            {
+                "name": "Speed Limiter - Disable",
+                "id": 197,
+                "type": "button",
+                "vjoy": 2,
+                "button": 17,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_off"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 200,
+                "type": "button",
+                "vjoy": 0,
+                "disabled": true,
+                "button": 0,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_speed_limiter_reset_scm"
+            },
+            {
+                "name": "Acceleration Limiter - Increase",
+                "id": 202,
+                "type": "button",
+                "vjoy": 2,
+                "button": 18,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_up"
+            },
+            {
+                "name": "Acceleration Limiter - Decrease",
+                "id": 203,
+                "type": "button",
+                "vjoy": 2,
+                "button": 19,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_down"
+            },
+            {
+                "name": "Acceleration Limiter - Step Up",
+                "id": 205,
+                "type": "button",
+                "vjoy": 2,
+                "button": 20,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_increment"
+            },
+            {
+                "name": "Acceleration Limiter - Step Down",
+                "id": 210,
+                "type": "button",
+                "vjoy": 2,
+                "button": 21,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_decrement"
+            },
+            {
+                "name": "Acceleration Limiter (relative)",
+                "id": 215,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 5,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_rel"
+            },
+            {
+                "name": "Acceleration Limiter (absolute)",
+                "id": 220,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 6,
+                "actionmap": "spaceship_movement",
+                "action": "v_accel_range_abs"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 225,
+                "type": "button",
+                "disabled": true,
+                "vjoy": 0,
+                "button": 0,
+                "actionmap": "spaceship_movement",
+                "action": "v_target_match_vel"
+            },
+            {
+                "name": "Spacebrake",
+                "id": 230,
+                "type": "button",
+                "vjoy": 2,
+                "button": 22,
+                "actionmap": "spaceship_movement",
+                "action": "v_space_brake"
+            },
+            {
+                "name": "Lock Pitch/Yaw Movement (Toggle/Hold)",
+                "id": 235,
+                "type": "button",
+                "vjoy": 2,
+                "button": 23,
+                "actionmap": "spaceship_movement",
+                "action": "v_lock_rotation"
+            },
+            {
+                "name": "G-Force Safety Toggle",
+                "id": 240,
+                "type": "button",
+                "vjoy": 2,
+                "button": 24,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_toggle_gforce_safety"
+            },
+            {
+                "name": "G-Force Safety On",
+                "id": 241,
+                "type": "button",
+                "vjoy": 2,
+                "button": 25,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gsafe_on"
+            },
+            {
+                "name": "G-Force Safety Off",
+                "id": 242,
+                "type": "button",
+                "vjoy": 2,
+                "button": 26,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gsafe_off"
+            },
+            {
+                "name": "E.S.P. - Toggle On/Off (Press)",
+                "id": 245,
+                "type": "button",
+                "vjoy": 2,
+                "button": 27,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_toggle_esp"
+            },
+            {
+                "name": "E.S.P. - Enable Temporarily (Hold)",
+                "id": 250,
+                "type": "button",
+                "vjoy": 2,
+                "button": 28,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_esp_hold"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 255,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "Landing System (Toggle)",
+                "id": 260,
+                "type": "button",
+                "vjoy": 2,
+                "button": 29,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_landing_system"
+            },
+            {
+                "name": "Landing System (Deploy)",
+                "id": 265,
+                "type": "button",
+                "vjoy": 2,
+                "button": 30,
+                "actionmap": "spaceship_movement",
+                "action": "v_deploy_landing_system"
+            },
+            {
+                "name": "Landing System (Retract)",
+                "id": 270,
+                "type": "button",
+                "vjoy": 2,
+                "button": 31,
+                "actionmap": "spaceship_movement",
+                "action": "v_retract_landing_system"
+            },
+            {
+                "name": "Toggle VTOL",
+                "id": 275,
+                "type": "button",
+                "vjoy": 2,
+                "button": 32,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_toggle"
+            },
+            {
+                "name": "Enable VTOL",
+                "id": 276,
+                "type": "button",
+                "vjoy": 2,
+                "button": 33,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_on"
+            },
+            {
+                "name": "Disable VTOL",
+                "id": 277,
+                "type": "button",
+                "vjoy": 2,
+                "button": 34,
+                "actionmap": "spaceship_movement",
+                "action": "v_vtol_off"
+            },
+            {
+                "name": "Expand Configuration",
+                "id": 280,
+                "type": "button",
+                "vjoy": 2,
+                "button": 35,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_deploy"
+            },
+            {
+                "name": "Retract Configuration",
+                "id": 285,
+                "type": "button",
+                "vjoy": 2,
+                "button": 36,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_retract"
+            },
+            {
+                "name": "Cycle Configuration",
+                "id": 290,
+                "type": "button",
+                "vjoy": 2,
+                "button": 37,
+                "actionmap": "spaceship_movement",
+                "action": "v_transform_cycle"
+            },
+            {
+                "name": "Autoland",
+                "id": 295,
+                "type": "button",
+                "vjoy": 2,
+                "button": 38,
+                "actionmap": "spaceship_movement",
+                "action": "v_autoland"
+            },
+            {
+                "name": "Requst Landing",
+                "id": 300,
+                "type": "button",
+                "vjoy": 2,
+                "button": 39,
+                "actionmap": "spaceship_movement",
+                "action": "v_atc_request"
+            },
+            {
+                "name": "Request Cargo Loading",
+                "id": 305,
+                "type": "button",
+                "vjoy": 2,
+                "button": 40,
+                "actionmap": "spaceship_movement",
+                "action": "v_atc_loading_area_request"
+            },
+            {
+                "name": "Cycle Master Mode (short)",
+                "id": 310,
+                "type": "button",
+                "vjoy": 2,
+                "button": 41,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_cycle"
+            },
+            {
+                "name": "Cycle Master Mode (long)",
+                "id": 311,
+                "type": "button",
+                "vjoy": 2,
+                "button": 42,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_cycle_long"
+            },
+            {
+                "name": "Set Master Mode to Nav",
+                "id": 312,
+                "type": "button",
+                "vjoy": 2,
+                "button": 43,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_set_nav"
+            },
+            {
+                "name": "Set Master Mode to SCM",
+                "id": 313,
+                "type": "button",
+                "vjoy": 2,
+                "button": 44,
+                "actionmap": "spaceship_movement",
+                "action": "v_master_mode_set_scm"
+            },
+            {
+                "name": "Jump Drive - Request Jump",
+                "id": 315,
+                "type": "button",
+                "vjoy": 2,
+                "button": 45,
+                "actionmap": "spaceship_movement",
+                "action": "v_toggle_jump_request"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 320,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Toggle",
+                "id": 325,
+                "type": "button",
+                "vjoy": 2,
+                "button": 46,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_toggle"
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Enable",
+                "id": 330,
+                "type": "button",
+                "vjoy": 2,
+                "button": 47,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_on"
+            },
+            {
+                "name": "IFSC - Gravity Compensation - Disable",
+                "id": 335,
+                "type": "button",
+                "vjoy": 2,
+                "button": 48,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_gravity_compensation_off"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Toggle",
+                "id": 337,
+                "type": "button",
+                "vjoy": 2,
+                "button": 49,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_toggle"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Enable",
+                "id": 338,
+                "type": "button",
+                "vjoy": 2,
+                "button": 50,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_on"
+            },
+            {
+                "name": "IFSC - Wind Compensation - Disable",
+                "id": 339,
+                "type": "button",
+                "vjoy": 2,
+                "button": 51,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_wind_compensation_off"
+            },
+            {
+                "name": "Automatic Precision Mode - Toggle",
+                "id": 340,
+                "type": "button",
+                "vjoy": 2,
+                "button": 52,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_toggle"
+            },
+            {
+                "name": "Automatic Precision Mode - Enable",
+                "id": 345,
+                "type": "button",
+                "vjoy": 2,
+                "button": 53,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_on"
+            },
+            {
+                "name": "Automatic Precision Mode - Disable",
+                "id": 350,
+                "type": "button",
+                "vjoy": 2,
+                "button": 54,
+                "actionmap": "spaceship_movement",
+                "action": "v_auto_precision_mode_off"
+            },
+            {
+                "name": "IFSC Proximity Assist Toggle",
+                "id": 355,
+                "type": "button",
+                "vjoy": 2,
+                "button": 55,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_toggle"
+            },
+            {
+                "name": "IFSC Proximity Assist On",
+                "id": 360,
+                "type": "button",
+                "vjoy": 2,
+                "button": 56,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_on"
+            },
+            {
+                "name": "IFSC Proximity Assist Off",
+                "id": 365,
+                "type": "button",
+                "vjoy": 2,
+                "button": 57,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_proximity_assist_off"
+            },
+            {
+                "name": "IFSC - Stability Toggle",
+                "id": 367,
+                "type": "button",
+                "vjoy": 2,
+                "button": 58,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_toggle"
+            },
+            {
+                "name": "IFSC - Stability On",
+                "id": 368,
+                "type": "button",
+                "vjoy": 2,
+                "button": 59,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_on"
+            },
+            {
+                "name": "IFSC - Stability Off",
+                "id": 369,
+                "type": "button",
+                "vjoy": 2,
+                "button": 60,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_stability_off"
+            },
+            {
+                "name": "Reset Flight Accelerometer",
+                "id": 370,
+                "type": "button",
+                "vjoy": 2,
+                "button": 61,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_reset_gmeter_max"
+            },
+            {
+                "name": "Advanced HUD - Toggle",
+                "id": 375,
+                "type": "button",
+                "vjoy": 2,
+                "button": 62,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_toggle"
+            },
+            {
+                "name": "Advanced HUD - Enable",
+                "id": 380,
+                "type": "button",
+                "vjoy": 2,
+                "button": 63,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_on"
+            },
+            {
+                "name": "Advanced HUD - Disable",
+                "id": 385,
+                "type": "button",
+                "vjoy": 2,
+                "button": 64,
+                "actionmap": "spaceship_movement",
+                "action": "v_flight_advanced_hud_off"
+            },
+            {
+                "name": "IFSC - Command Behaviour Toggle",
+                "id": 390,
+                "type": "button",
+                "vjoy": 2,
+                "button": 65,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_toggle"
+            },
+            {
+                "name": "IFSC - Command Behaviour On",
+                "id": 400,
+                "type": "button",
+                "vjoy": 2,
+                "button": 66,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_on"
+            },
+            {
+                "name": "IFSC - Command Behaviour Off",
+                "id": 405,
+                "type": "button",
+                "vjoy": 2,
+                "button": 67,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_command_off"
+            },
+            {
+                "name": "IFSC - Core Toggle",
+                "id": 410,
+                "type": "button",
+                "vjoy": 2,
+                "button": 68,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_toggle"
+            },
+            {
+                "name": "IFSC - Core On",
+                "id": 415,
+                "type": "button",
+                "vjoy": 2,
+                "button": 69,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_on"
+            },
+            {
+                "name": "IFSC - Core Off",
+                "id": 420,
+                "type": "button",
+                "vjoy": 2,
+                "button": 70,
+                "actionmap": "spaceship_movement",
+                "action": "v_ifcs_core_off"
+            }
+        ]
+    },
+    {
+        "category_id": 30,
+        "name": "Flight - Quantum Travel",
+        "values": [
+            {
+                "name": "Engage Quantum Drive (Hold)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 71,
+                "actionmap": "spaceship_quantum",
+                "action": "v_toggle_qdrive_engagement"
+            }
+        ]
+    },
+    {
+        "category_id": 35,
+        "name": "Flight - Docking",
+        "values": [
+            {
+                "name": "Toggle Docking Mode",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 72,
+                "actionmap": "spaceship_docking",
+                "action": "v_toggle_docking_mode"
+            },
+            {
+                "name": "Invoke Docking",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 73,
+                "actionmap": "spaceship_docking",
+                "action": "v_invoke_docking"
+            },
+            {
+                "name": "Toggle Docking Camera",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 74,
+                "actionmap": "spaceship_docking",
+                "action": "v_dock_toggle_view"
+            }
+        ]
+    },
+    {
+        "category_id": 40,
+        "name": "Vehicles - Targeting",
+        "values": [
+            {
+                "name": "Auto Targeting - Toggle On/Off (long)",
+                "id": 1,
+                "type": "button",
+                "vjoy": 2,
+                "button": 75,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_toggle_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle On/Off (short)",
+                "id": 2,
+                "type": "button",
+                "vjoy": 2,
+                "button": 76,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_toggle_short"
+            },
+            {
+                "name": "Auto Targeting - Toggle On (long)",
+                "id": 4,
+                "type": "button",
+                "vjoy": 2,
+                "button": 77,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_enable_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle On (short)",
+                "id": 5,
+                "type": "button",
+                "vjoy": 2,
+                "button": 78,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_enable_short"
+            },
+            {
+                "name": "Auto Targeting - Toggle Off (long)",
+                "id": 7,
+                "type": "button",
+                "vjoy": 2,
+                "button": 79,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_disable_long"
+            },
+            {
+                "name": "Auto Targeting - Toggle Off (short)",
+                "id": 8,
+                "type": "button",
+                "vjoy": 2,
+                "button": 80,
+                "actionmap": "spaceship_targeting",
+                "action": "v_auto_targeting_disable_short"
+            },
+            {
+                "name": "Pin Index 1 - Lock/Unlock Pinned Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 81,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_1"
+            },
+            {
+                "name": "Pin Index 2 - Lock/Unlock Pinned Target",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 82,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_2"
+            },
+            {
+                "name": "Pin Index 3 - Lock/Unlock Pinned Target",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 83,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_lock_index_3"
+            },
+            {
+                "name": "Pin Index 1 - Pin/Unpin Selected Target",
+                "id": 25,
+                "type": "button",
+                "vjoy": 2,
+                "button": 84,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_1"
+            },
+            {
+                "name": "Pin Index 2 - Pin/Unpin Selected Target",
+                "id": 30,
+                "type": "button",
+                "vjoy": 2,
+                "button": 85,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_2"
+            },
+            {
+                "name": "Pin Index 3 - Pin/Unpin Selected Target",
+                "id": 35,
+                "type": "button",
+                "vjoy": 2,
+                "button": 86,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_3"
+            },
+            {
+                "name": "Pin Index 1 - Pin/Unpin Selected Target (hold)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 2,
+                "button": 87,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_1_hold"
+            },
+            {
+                "name": "Pin Index 2 - Pin/Unpin Selected Target (hold)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 2,
+                "button": 88,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_2_hold"
+            },
+            {
+                "name": "Pin Index 3 - Pin/Unpin Selected Target (hold)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 2,
+                "button": 89,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_toggle_pin_index_3_hold"
+            },
+            {
+                "name": "Pin Selected Target",
+                "id": 55,
+                "type": "button",
+                "vjoy": 2,
+                "button": 90,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_pin_selected"
+            },
+            {
+                "name": "Unpin Selected Target",
+                "id": 60,
+                "type": "button",
+                "vjoy": 2,
+                "button": 91,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unpin_selected"
+            },
+            {
+                "name": "Pin Selected Target (hold)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 2,
+                "button": 92,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_pin_selected_hold"
+            },
+            {
+                "name": "Unpin Selected Target (hold)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 2,
+                "button": 93,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unpin_selected_hold"
+            },
+            {
+                "name": "Remove All Pinned Targets",
+                "id": 75,
+                "type": "button",
+                "vjoy": 2,
+                "button": 94,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_remove_all_pins"
+            },
+            {
+                "name": "Lock Selected Target",
+                "id": 80,
+                "type": "button",
+                "vjoy": 2,
+                "button": 95,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_lock_selected"
+            },
+            {
+                "name": "Unlock Current Target",
+                "id": 85,
+                "type": "button",
+                "vjoy": 2,
+                "button": 96,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_unlock"
+            },
+            {
+                "name": "Enable/Disable Look Ahead",
+                "id": 90,
+                "type": "button",
+                "vjoy": 2,
+                "button": 97,
+                "actionmap": "spaceship_targeting",
+                "action": "v_look_ahead_enable"
+            },
+            {
+                "name": "Enable/Disable Target Padlock (Toggle, Hold)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 2,
+                "button": 98,
+                "actionmap": "spaceship_targeting",
+                "action": "v_look_ahead_start_target_tracking"
+            },
+            {
+                "name": "Auto Zoom On Selected Target On/Off (Toggle, Hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 2,
+                "button": 99,
+                "actionmap": "spaceship_targeting",
+                "action": "v_target_tracking_auto_zoom"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 110,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_1"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 115,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_2"
+            },
+            {
+                "name": "Moved to Vehicles - Seat and Operator Modes",
+                "id": 120,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_targeting",
+                "action": "v_enter_remote_turret_3"
+            }
+        ]
+    },
+    {
+        "category_id": 45,
+        "name": "Vehicles - Target Cycling",
+        "values": [
+            {
+                "name": "Lock Target Under Reticle",
+                "id": 1,
+                "type": "button",
+                "vjoy": 2,
+                "button": 100,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_under_reticle"
+            },
+            {
+                "name": "Cycle Lock - In View - Back",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 101,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_back"
+            },
+            {
+                "name": "Cycle Lock - In View - Forward",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 102,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_fwd"
+            },
+            {
+                "name": "Cycle Lock - In View - Under Reticle",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 103,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_in_view_reset"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Back",
+                "id": 25,
+                "type": "button",
+                "vjoy": 2,
+                "button": 104,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_back"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Forward",
+                "id": 30,
+                "type": "button",
+                "vjoy": 2,
+                "button": 105,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_fwd"
+            },
+            {
+                "name": "Cycle Lock - Pinned - Reset to First",
+                "id": 35,
+                "type": "button",
+                "vjoy": 2,
+                "button": 106,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_pinned_reset"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Back",
+                "id": 40,
+                "type": "button",
+                "vjoy": 2,
+                "button": 107,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_back"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Forward",
+                "id": 45,
+                "type": "button",
+                "vjoy": 2,
+                "button": 108,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_fwd"
+            },
+            {
+                "name": "Cycle Lock - Attackers - Reset to Closest",
+                "id": 50,
+                "type": "button",
+                "vjoy": 2,
+                "button": 109,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_attacker_reset"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Back",
+                "id": 55,
+                "type": "button",
+                "vjoy": 2,
+                "button": 110,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_back"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Forward",
+                "id": 60,
+                "type": "button",
+                "vjoy": 2,
+                "button": 111,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_fwd"
+            },
+            {
+                "name": "Cycle Lock - Hostiles - Reset to Closest",
+                "id": 65,
+                "type": "button",
+                "vjoy": 2,
+                "button": 112,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_hostile_reset"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Back",
+                "id": 70,
+                "type": "button",
+                "vjoy": 2,
+                "button": 113,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_back"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Forward",
+                "id": 75,
+                "type": "button",
+                "vjoy": 2,
+                "button": 114,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_fwd"
+            },
+            {
+                "name": "Cycle Lock - Friendlies - Reset to Closest",
+                "id": 80,
+                "type": "button",
+                "vjoy": 2,
+                "button": 115,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_friendly_reset"
+            },
+            {
+                "name": "Cycle Lock - All - Back",
+                "id": 85,
+                "type": "button",
+                "vjoy": 2,
+                "button": 116,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_back"
+            },
+            {
+                "name": "Cycle Lock - All - Forward",
+                "id": 90,
+                "type": "button",
+                "vjoy": 2,
+                "button": 117,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_fwd"
+            },
+            {
+                "name": "Cycle Lock - All - Reset to Closest",
+                "id": 95,
+                "type": "button",
+                "vjoy": 2,
+                "button": 118,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_all_reset"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Back",
+                "id": 100,
+                "type": "button",
+                "vjoy": 2,
+                "button": 119,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_back"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Forward",
+                "id": 110,
+                "type": "button",
+                "vjoy": 2,
+                "button": 120,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_fwd"
+            },
+            {
+                "name": "Cycle Lock - Sub-Target - Reset to Main Target",
+                "id": 115,
+                "type": "button",
+                "vjoy": 2,
+                "button": 121,
+                "actionmap": "spaceship_targeting_advanced",
+                "action": "v_target_cycle_subitem_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 50,
+        "name": "Flight - Target Hailing",
+        "values": [
+            {
+                "name": "Hail Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 122,
+                "actionmap": "spaceship_target_hailing",
+                "action": "v_target_hail"
+            }
+        ]
+    },
+    {
+        "category_id": 55,
+        "name": "Flight - Radar",
+        "values": [
+            {
+                "name": "Activate Ping (Hold & Release)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 123,
+                "actionmap": "spaceship_radar",
+                "action": "v_invoke_ping"
+            }
+        ]
+    },
+    {
+        "category_id": 60,
+        "name": "Vehicles - Scanning",
+        "values": [
+            {
+                "name": "Activate Scanning",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 124,
+                "actionmap": "spaceship_scanning",
+                "action": "v_scanning_trigger_scan"
+            },
+            {
+                "name": "Increase Scanning Angle",
+                "id": 15,
+                "type": "button",
+                "vjoy": 2,
+                "button": 125,
+                "actionmap": "spaceship_scanning",
+                "action": "v_inc_scan_focus_level"
+            },
+            {
+                "name": "Decrease Scanning Angle",
+                "id": 20,
+                "type": "button",
+                "vjoy": 2,
+                "button": 126,
+                "actionmap": "spaceship_scanning",
+                "action": "v_dec_scan_focus_level"
+            }
+        ]
+    },
+    {
+        "category_id": 65,
+        "name": "Vehicles - Mining",
+        "values": [
+            {
+                "name": "Fire Mining Laser (Toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 2,
+                "button": 127,
+                "actionmap": "spaceship_mining",
+                "action": "v_toggle_mining_laser_fire"
+            },
+            {
+                "name": "Switch Mining Laser (Toggle)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 1,
+                "actionmap": "spaceship_mining",
+                "action": "v_toggle_mining_laser_type"
+            },
+            {
+                "name": "Increase Mining Laser Power",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 2,
+                "actionmap": "spaceship_mining",
+                "action": "v_increase_mining_throttle"
+            },
+            {
+                "name": "Decrease Mining Laser Power",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 3,
+                "actionmap": "spaceship_mining",
+                "action": "v_decrease_mining_throttle"
+            },
+            {
+                "name": "Increase/Decrease Mining Laser Power",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 7,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_throttle"
+            },
+            {
+                "name": "Activate Mining Module (Slot 1)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 4,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable1"
+            },
+            {
+                "name": "Activate Mining Module (Slot 2)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 5,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable2"
+            },
+            {
+                "name": "Activate Mining Module (Slot 3)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 6,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_consumable3"
+            },
+            {
+                "name": "Use Permanent Modifier",
+                "id": 47,
+                "type": "button",
+                "vjoy": 3,
+                "button": 7,
+                "actionmap": "spaceship_mining",
+                "action": "v_mining_use_permanent_modifier"
+            },
+            {
+                "name": "Jettison Cargo",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 8,
+                "actionmap": "spaceship_mining",
+                "action": "v_jettison_volatile_cargo"
+            }
+        ]
+    },
+    {
+        "category_id": 70,
+        "name": "Vehicles - Salvaging",
+        "values": [
+            {
+                "name": "Tractor Beam Vehicle - Increase Distance",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 9,
+                "actionmap": "spaceship_salvage",
+                "action": "tractor_beam_vehicle_increase_distance"
+            },
+            {
+                "name": "Tractor Beam Vehicle - Decrease Distance",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 10,
+                "actionmap": "spaceship_salvage",
+                "action": "tractor_beam_vehicle_decrease_distance"
+            },
+            {
+                "name": "Toggle Fire Focused",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 11,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_focused"
+            },
+            {
+                "name": "Toggle Fire Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 12,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_left"
+            },
+            {
+                "name": "Toggle Fire Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 13,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_right"
+            },
+            {
+                "name": "Toggle Fire Fracture",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 14,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_fracture"
+            },
+            {
+                "name": "Toggle Fire Disintegrate",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 15,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_fire_disintegrate"
+            },
+            {
+                "name": "Salvage Mode Gimbal (Toggle)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 16,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_gimbal_mode"
+            },
+            {
+                "name": "Salvage Mode Gimbal Reset",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 17,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_reset_gimbal"
+            },
+            {
+                "name": "Increase Beam Spacing",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 18,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_increase_beam_spacing"
+            },
+            {
+                "name": "Decrease Beam Spacing",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 19,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_decrease_beam_spacing"
+            },
+            {
+                "name": "Relative Beam Spacing",
+                "id": 65,
+                "type": "axis",
+                "vjoy": 2,
+                "axis": 8,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_beam_spacing_rel"
+            },
+            {
+                "name": "Absolute Beam Spacing",
+                "id": 70,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 1,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_beam_spacing_abs"
+            },
+            {
+                "name": "Salvage Beam Axis (Toggle)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 20,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_toggle_beam_spacing_axis"
+            },
+            {
+                "name": "Cycle Focused Salvage Modifiers",
+                "id": 80,
+                "type": "button",
+                "vjoy": 3,
+                "button": 21,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_focused"
+            },
+            {
+                "name": "Cycle Left Salvage Modifiers",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 22,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_left"
+            },
+            {
+                "name": "Cycle Right Salvage Modifiers",
+                "id": 90,
+                "type": "button",
+                "vjoy": 3,
+                "button": 23,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_right"
+            },
+            {
+                "name": "Cycle Structural Salvage Modifiers",
+                "id": 95,
+                "type": "button",
+                "vjoy": 3,
+                "button": 24,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_cycle_modifiers_structural"
+            },
+            {
+                "name": "Focus All Salvage Heads",
+                "id": 110,
+                "type": "button",
+                "vjoy": 3,
+                "button": 25,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_all_heads"
+            },
+            {
+                "name": "Focus Left Salvage Head",
+                "id": 115,
+                "type": "button",
+                "vjoy": 3,
+                "button": 26,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_left"
+            },
+            {
+                "name": "Focus Right Salvage Head",
+                "id": 120,
+                "type": "button",
+                "vjoy": 3,
+                "button": 27,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_right"
+            },
+            {
+                "name": "Focus Fracture Tool",
+                "id": 125,
+                "type": "button",
+                "vjoy": 3,
+                "button": 28,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_fracture"
+            },
+            {
+                "name": "Focus Disintegration Tool",
+                "id": 130,
+                "type": "button",
+                "vjoy": 3,
+                "button": 29,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_focus_disintegrate"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Up",
+                "id": 135,
+                "type": "button",
+                "vjoy": 3,
+                "button": 30,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_up__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Down",
+                "id": 140,
+                "type": "button",
+                "vjoy": 3,
+                "button": 31,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_down__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Left",
+                "id": 145,
+                "type": "button",
+                "vjoy": 3,
+                "button": 32,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_left__left"
+            },
+            {
+                "name": "Nudge Left Salvage Tool Right",
+                "id": 150,
+                "type": "button",
+                "vjoy": 3,
+                "button": 33,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_left__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Up",
+                "id": 155,
+                "type": "button",
+                "vjoy": 3,
+                "button": 34,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_up__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Down",
+                "id": 160,
+                "type": "button",
+                "vjoy": 3,
+                "button": 35,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_down__right"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Left",
+                "id": 165,
+                "type": "button",
+                "vjoy": 3,
+                "button": 36,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_right__left"
+            },
+            {
+                "name": "Nudge Right Salvage Tool Right",
+                "id": 170,
+                "type": "button",
+                "vjoy": 3,
+                "button": 37,
+                "actionmap": "spaceship_salvage",
+                "action": "v_salvage_nudge_right__right"
+            }
+        ]
+    },
+    {
+        "category_id": 75,
+        "name": "Turret - Movement",
+        "values": [
+            {
+                "name": "Pitch Up",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 38,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 39,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch_down"
+            },
+            {
+                "name": "Pitch",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 2,
+                "actionmap": "turret_movement",
+                "action": "turret_pitch"
+            },
+            {
+                "name": "Yaw Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 40,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw_left"
+            },
+            {
+                "name": "Yaw Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 41,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw_right"
+            },
+            {
+                "name": "Yaw",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 3,
+                "actionmap": "turret_movement",
+                "action": "turret_yaw"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll_left"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll_right"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 0,
+                "axis": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_roll"
+            },
+            {
+                "name": "Toggle Turret Mouse Movement (FPS Style)",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 42,
+                "actionmap": "turret_movement",
+                "action": "turret_toggle_mouse_mode"
+            },
+            {
+                "name": "Exit Remote Turret",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 43,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_exit"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_in"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_out"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 75,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_zoom_toggle"
+            },
+            {
+                "name": "Turret Gyro Stabilization (Toggle)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 3,
+                "button": 44,
+                "actionmap": "turret_movement",
+                "action": "turret_gyromode"
+            },
+            {
+                "name": "Next Remote Turret",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 45,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_cycle_next"
+            },
+            {
+                "name": "Previous Remote Turrent",
+                "id": 86,
+                "type": "button",
+                "vjoy": 3,
+                "button": 46,
+                "actionmap": "turret_movement",
+                "action": "turret_remote_cycle_prev"
+            }
+        ]
+    },
+    {
+        "category_id": 80,
+        "name": "Turret - Advanced",
+        "values": [
+            {
+                "name": "Turret E.S.P. - Toggle On/Off",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 47,
+                "actionmap": "turret_advanced",
+                "action": "turret_esp_toggle"
+            },
+            {
+                "name": "Turret E.S.P. - Enable Temporarily (Hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 48,
+                "actionmap": "turret_advanced",
+                "action": "turret_esp_hold"
+            },
+            {
+                "name": "Recenter Turret (Hold)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 49,
+                "actionmap": "turret_advanced",
+                "action": "turret_recenter"
+            },
+            {
+                "name": "Turret - Speed Limiter - On/Off (Hold/Toggle)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 50,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_toggle"
+            },
+            {
+                "name": "Turret - Speed Limiter (relative)",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 4,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel"
+            },
+            {
+                "name": "Turret - Speed Limiter - Increase (relative)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 51,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel_increase"
+            },
+            {
+                "name": "Turret - Speed Limiter - Decrease (relative) ",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 52,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_rel_decrease"
+            },
+            {
+                "name": "Turret - Speed Limiter (absolute)",
+                "id": 45,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 5,
+                "actionmap": "turret_advanced",
+                "action": "turret_limiter_abs"
+            },
+            {
+                "name": "Cycle Fire Mode (staggered/combined)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 53,
+                "actionmap": "turret_advanced",
+                "action": "turret_change_firemode"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "turret_advanced",
+                "action": "turret_instant_zoom"
+            },
+            {
+                "name": "Turret Change Position",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 54,
+                "actionmap": "turret_advanced",
+                "action": "turret_change_position"
+            }
+        ]
+    },
+    {
+        "category_id": 85,
+        "name": "Vehicles - Weapons",
+        "values": [
+            {
+                "name": "Gimbal Toggle",
+                "id": 5,
+                "type": "button",
+                "vjoy": 3,
+                "button": 55,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_toggle"
+            },
+            {
+                "name": "Gimbal Set to Locked",
+                "id": 6,
+                "type": "button",
+                "vjoy": 3,
+                "button": 56,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_set_locked"
+            },
+            {
+                "name": "Gimbal Set to Unlocked",
+                "id": 7,
+                "type": "button",
+                "vjoy": 3,
+                "button": 57,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_state_set_unlocked"
+            },
+            {
+                "name": "Gimbal Unlocked Cycle",
+                "id": 7,
+                "type": "button",
+                "vjoy": 3,
+                "button": 58,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbals_unlocked_cycle_source"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 10,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_all"
+            },
+            {
+                "name": "Aim Type - Cycle",
+                "id": 11,
+                "type": "button",
+                "vjoy": 3,
+                "button": 59,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_cycle"
+            },
+            {
+                "name": "Aim Type - PIP Aiming",
+                "id": 12,
+                "type": "button",
+                "vjoy": 3,
+                "button": 60,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_pip_aiming"
+            },
+            {
+                "name": "Aim Type - Painting",
+                "id": 13,
+                "type": "button",
+                "vjoy": 3,
+                "button": 61,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_painting"
+            },
+            {
+                "name": "Aim Type - Auto",
+                "id": 14,
+                "type": "button",
+                "vjoy": 3,
+                "button": 62,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_aim_type_set_auto"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 15,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_group1"
+            },
+            {
+                "name": "Staggered Fire - Toggle",
+                "id": 16,
+                "type": "button",
+                "vjoy": 3,
+                "button": 63,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_toggle"
+            },
+            {
+                "name": "Staggered Fire - On",
+                "id": 17,
+                "type": "button",
+                "vjoy": 3,
+                "button": 64,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_on"
+            },
+            {
+                "name": "Staggered Fire - Off",
+                "id": 18,
+                "type": "button",
+                "vjoy": 3,
+                "button": 65,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_staggered_fire_off"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 20,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_attack_group2"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 25,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_manual_gimbal_cycle_source"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 30,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_manual_gimbal_lock_vector"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 35,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_cycle_all"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_cycle_fixed_auto"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_fixed_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_auto_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_manual_long"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 60,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_fixed"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_manual"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_gimbal_mode_set_auto"
+            },
+            {
+                "name": "Suppress Aim Assists (hold)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 66,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_suppress_aim_assists_hold"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 80,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_change_firemode"
+            },
+            {
+                "name": "Toggle Lead/Lag PIPs",
+                "id": 85,
+                "type": "button",
+                "vjoy": 3,
+                "button": 67,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_toggle_lead_lag"
+            },
+            {
+                "name": "Set Lag PIPs",
+                "id": 90,
+                "type": "button",
+                "vjoy": 3,
+                "button": 68,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_set_lag"
+            },
+            {
+                "name": "Set Lead PIPs",
+                "id": 95,
+                "type": "button",
+                "vjoy": 3,
+                "button": 69,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_set_lead"
+            },
+            {
+                "name": "PIP Combination Type: Toggle",
+                "id": 100,
+                "type": "button",
+                "vjoy": 3,
+                "button": 70,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_toggle"
+            },
+            {
+                "name": "PIP Combination Type: Set One PIP per Weapon",
+                "id": 110,
+                "type": "button",
+                "vjoy": 3,
+                "button": 71,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_set_single"
+            },
+            {
+                "name": "PIP Combination Type: Set One PIP per Weapon Type",
+                "id": 115,
+                "type": "button",
+                "vjoy": 3,
+                "button": 72,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_combination_type_set_combined_weapon_group"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 120,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "",
+                "action": ""
+            },
+            {
+                "name": "PIP Precision Lines Toggle",
+                "id": 117,
+                "type": "button",
+                "vjoy": 3,
+                "button": 73,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_toggle"
+            },
+            {
+                "name": "PIP Precision Lines On",
+                "id": 118,
+                "type": "button",
+                "vjoy": 3,
+                "button": 74,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_on"
+            },
+            {
+                "name": "PIP Precision Lines Off",
+                "id": 119,
+                "type": "button",
+                "vjoy": 3,
+                "button": 75,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_prec_line_off"
+            },
+            {
+                "name": "PIP Fading Toggle",
+                "id": 121,
+                "type": "button",
+                "vjoy": 3,
+                "button": 76,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_toggle"
+            },
+            {
+                "name": "PIP Fading On",
+                "id": 122,
+                "type": "button",
+                "vjoy": 3,
+                "button": 77,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_on"
+            },
+            {
+                "name": "PIP Fading Off",
+                "id": 123,
+                "type": "button",
+                "vjoy": 3,
+                "button": 78,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_pip_fade_off"
+            },
+            {
+                "name": "Gunnery UI Magnification Toggle",
+                "id": 125,
+                "type": "button",
+                "vjoy": 3,
+                "button": 79,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_toggle"
+            },
+            {
+                "name": "Gunnery UI Magnification On",
+                "id": 126,
+                "type": "button",
+                "vjoy": 3,
+                "button": 80,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_on"
+            },
+            {
+                "name": "Gunnery UI Magnification Off",
+                "id": 127,
+                "type": "button",
+                "vjoy": 3,
+                "button": 81,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ui_scale_off"
+            },
+            {
+                "name": "Manual Convergence Distance (relative)",
+                "id": 130,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 6,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel"
+            },
+            {
+                "name": "Manual Convergence Distance - Increase",
+                "id": 131,
+                "type": "button",
+                "vjoy": 3,
+                "button": 82,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel_increase"
+            },
+            {
+                "name": "Manual Convergence Distance - Decrease",
+                "id": 132,
+                "type": "button",
+                "vjoy": 3,
+                "button": 83,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_rel_decrease"
+            },
+            {
+                "name": "Manual Convergence Distance (absolute)",
+                "id": 140,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 7,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_abs"
+            },
+            {
+                "name": "Manual Convergence Distance - Reset",
+                "id": 145,
+                "type": "button",
+                "vjoy": 3,
+                "button": 84,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_convergence_distance_set_default"
+            },
+            {
+                "name": "Weapon Preset - Fire",
+                "id": 150,
+                "type": "button",
+                "vjoy": 3,
+                "button": 85,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_attack"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 1",
+                "id": 151,
+                "type": "button",
+                "vjoy": 3,
+                "button": 86,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns0"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 2",
+                "id": 152,
+                "type": "button",
+                "vjoy": 3,
+                "button": 87,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns1"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 3",
+                "id": 153,
+                "type": "button",
+                "vjoy": 3,
+                "button": 88,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns2"
+            },
+            {
+                "name": "Weapon Preset - Fire Guns Group 4",
+                "id": 154,
+                "type": "button",
+                "vjoy": 3,
+                "button": 89,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_fire_guns3"
+            },
+            {
+                "name": "Weapon Preset - Next",
+                "id": 155,
+                "type": "button",
+                "vjoy": 3,
+                "button": 90,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_next"
+            },
+            {
+                "name": "Weapon Preset - Previous",
+                "id": 160,
+                "type": "button",
+                "vjoy": 3,
+                "button": 91,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_prev"
+            },
+            {
+                "name": "Weapon Preset - Next (overflow)",
+                "id": 162,
+                "type": "button",
+                "vjoy": 3,
+                "button": 92,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_next_overflow"
+            },
+            {
+                "name": "Weapon Preset - Previous (overflow)",
+                "id": 163,
+                "type": "button",
+                "vjoy": 3,
+                "button": 93,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_prev_overflow"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 165,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_hold"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 170,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_toggle"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 175,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_stable_max_zoom_hold"
+            },
+            {
+                "name": "Control Moved to Vehicles - View",
+                "id": 180,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_ads_cycle_tracking"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 1",
+                "id": 185,
+                "type": "button",
+                "vjoy": 3,
+                "button": 94,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns0"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 2",
+                "id": 186,
+                "type": "button",
+                "vjoy": 3,
+                "button": 95,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns1"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 3",
+                "id": 187,
+                "type": "button",
+                "vjoy": 3,
+                "button": 96,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns2"
+            },
+            {
+                "name": "Weapon Preset - Set Gun Group 4",
+                "id": 188,
+                "type": "button",
+                "vjoy": 3,
+                "button": 97,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_guns3"
+            },
+            {
+                "name": "Weapon Preset - Set EMPs",
+                "id": 190,
+                "type": "button",
+                "vjoy": 3,
+                "button": 98,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_emp"
+            },
+            {
+                "name": "Weapon Preset - Set Quantum Jammers (short range)",
+                "id": 195,
+                "type": "button",
+                "vjoy": 3,
+                "button": 99,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid_jammer"
+            },
+            {
+                "name": "Weapon Preset - Set Quantum Snares / Pulse (long range)",
+                "id": 200,
+                "type": "button",
+                "vjoy": 3,
+                "button": 100,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid_pulse"
+            },
+            {
+                "name": "Weapon Preset - Set QIDs",
+                "id": 205,
+                "type": "button",
+                "vjoy": 3,
+                "button": 101,
+                "actionmap": "spaceship_weapons",
+                "action": "v_weapon_preset_qid"
+            }
+        ]
+    },
+    {
+        "category_id": 90,
+        "name": "Vehicles - Missiles",
+        "values": [
+            {
+                "name": "Launch Missiles (Tap)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 102,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_toggle_launch_missile"
+            },
+            {
+                "name": "Launch Missiles (Hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 103,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile"
+            },
+            {
+                "name": "Cycle Next Missle Type",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 104,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_cycle_missile_fwd"
+            },
+            {
+                "name": "Cycle Previous Missle Type",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 105,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_cycle_missile_back"
+            },
+            {
+                "name": "Increase Number of Armed Missiles",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 106,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_increase_max_missiles"
+            },
+            {
+                "name": "Decrease Number of Armed Missiles",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 107,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_decrease_max_missiles"
+            },
+            {
+                "name": "Reset Number of Armed Missiles",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 108,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_reset_max_missiles"
+            },
+            {
+                "name": "Bombs - Toggle Desired Impact Point (tap)",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 109,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_toggle_desired_impact_point"
+            },
+            {
+                "name": "Bombs - Toggle Desired Impact Point (hold)",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 110,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_toggle_desired_impact_point_hold"
+            },
+            {
+                "name": "Bombs - Increase HUD Range",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 111,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_increase"
+            },
+            {
+                "name": "Bombs - Decrease HUD Range",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 112,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_decrease"
+            },
+            {
+                "name": "Bombs - Reset HUD Range",
+                "id": 65,
+                "type": "button",
+                "vjoy": 3,
+                "button": 113,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_bombing_hud_range_reset"
+            },
+            {
+                "name": "Enable Cinematic Camera (toggle)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 3,
+                "button": 114,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile_cinematic"
+            },
+            {
+                "name": "Enable Cinematic Camera (hold)",
+                "id": 75,
+                "type": "button",
+                "vjoy": 3,
+                "button": 115,
+                "actionmap": "spaceship_missiles",
+                "action": "v_weapon_launch_missile_cinematic_hold"
+            }
+        ]
+    },
+    {
+        "category_id": 95,
+        "name": "Vehicles - Shields and Countermeasures",
+        "values": [
+            {
+                "name": "Decoy - Launch Burst (tap), Set and Launch Burst (Hold)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 3,
+                "button": 116,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_launch"
+            },
+            {
+                "name": "Decoy - Increase Burst Size",
+                "id": 15,
+                "type": "button",
+                "vjoy": 3,
+                "button": 117,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_burst_decrease"
+            },
+            {
+                "name": "Decoy - Decrease Burst Size",
+                "id": 20,
+                "type": "button",
+                "vjoy": 3,
+                "button": 118,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_burst_increase"
+            },
+            {
+                "name": "Decoy - Panic Launch",
+                "id": 25,
+                "type": "button",
+                "vjoy": 3,
+                "button": 119,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_decoy_launch_panic"
+            },
+            {
+                "name": "Noise - Deploy",
+                "id": 30,
+                "type": "button",
+                "vjoy": 3,
+                "button": 120,
+                "actionmap": "spaceship_defensive",
+                "action": "v_weapon_countermeasure_noise_launch"
+            },
+            {
+                "name": "Raise Shield Level - Front",
+                "id": 35,
+                "type": "button",
+                "vjoy": 3,
+                "button": 121,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_forward"
+            },
+            {
+                "name": "Raise Shield Level - Back",
+                "id": 40,
+                "type": "button",
+                "vjoy": 3,
+                "button": 122,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_back"
+            },
+            {
+                "name": "Raise Shield Level - Left",
+                "id": 45,
+                "type": "button",
+                "vjoy": 3,
+                "button": 123,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_left"
+            },
+            {
+                "name": "Raise Shield Level - Right",
+                "id": 50,
+                "type": "button",
+                "vjoy": 3,
+                "button": 124,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_right"
+            },
+            {
+                "name": "Raise Shield Level - Top",
+                "id": 55,
+                "type": "button",
+                "vjoy": 3,
+                "button": 125,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_up"
+            },
+            {
+                "name": "Raise Shield Level - Bottom",
+                "id": 60,
+                "type": "button",
+                "vjoy": 3,
+                "button": 126,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_raise_level_down"
+            },
+            {
+                "name": "Reset Shield Level",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 1,
+                "actionmap": "spaceship_defensive",
+                "action": "v_shield_reset_level"
+            }
+        ]
+    },
+    {
+        "category_id": 100,
+        "name": "Category moved to Flight - Power",
+        "values": [
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 10,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 15,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 20,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 25,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 30,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 35,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_weapon_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 40,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 60,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 65,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_engine_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 70,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_increase"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 75,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_decrease"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 80,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 85,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 90,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_combined_increase_max"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 95,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_shield_combined_decrease_min"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 100,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_capacitor_assignment",
+                "action": "v_capacitor_assignment_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 105,
+        "name": "Flight - Power",
+        "values": [
+            {
+                "name": "Toggle Power - All",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 2,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle"
+            },
+            {
+                "name": "Set Power On",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 3,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_on"
+            },
+            {
+                "name": "Set Power Off",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 4,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_off"
+            },
+            {
+                "name": "Toggle Power - Thrusters",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 5,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_thrusters"
+            },
+            {
+                "name": "Set Thrusters Power On",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 6,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_thrusters_on"
+            },
+            {
+                "name": "Set Thrusters Power Off",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 7,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_thrusters_off"
+            },
+            {
+                "name": "Toggle Power - Shields",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 8,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_shields"
+            },
+            {
+                "name": "Set Shields Power On",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 9,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_shields_on"
+            },
+            {
+                "name": "Set Shields Power Off",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 10,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_shields_off"
+            },
+            {
+                "name": "Toggle Power - Weapons",
+                "id": 55,
+                "type": "button",
+                "vjoy": 4,
+                "button": 11,
+                "actionmap": "spaceship_power",
+                "action": "v_power_toggle_weapons"
+            },
+            {
+                "name": "Set Weapons Power On",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 12,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_weapons_on"
+            },
+            {
+                "name": "Set Weapons Power Off",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 13,
+                "actionmap": "spaceship_power",
+                "action": "v_power_set_weapons_off"
+            },
+            {
+                "name": "Decrease Throttle",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 14,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_down"
+            },
+            {
+                "name": "Decrease Throttle to Min",
+                "id": 75,
+                "type": "button",
+                "vjoy": 4,
+                "button": 15,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_min"
+            },
+            {
+                "name": "Increase Throttle",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 16,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_up"
+            },
+            {
+                "name": "Increase Throttle to Max",
+                "id": 85,
+                "type": "button",
+                "vjoy": 4,
+                "button": 17,
+                "actionmap": "spaceship_power",
+                "action": "v_power_throttle_max"
+            },
+            {
+                "name": "Engines - Increase (tap)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 18,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_increase"
+            },
+            {
+                "name": "Engines - Decrease (tap)",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 19,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_decrease"
+            },
+            {
+                "name": "Engines - Set to Max (hold)",
+                "id": 100,
+                "type": "button",
+                "vjoy": 4,
+                "button": 20,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_max"
+            },
+            {
+                "name": "Engines - Set to Min (hold)",
+                "id": 105,
+                "type": "button",
+                "vjoy": 4,
+                "button": 21,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_engine_min"
+            },
+            {
+                "name": "Shields - Increase (tap)",
+                "id": 110,
+                "type": "button",
+                "vjoy": 4,
+                "button": 22,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_increase"
+            },
+            {
+                "name": "Shields - Decrease (tap)",
+                "id": 115,
+                "type": "button",
+                "vjoy": 4,
+                "button": 23,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_decrease"
+            },
+            {
+                "name": "Shields - Set to Max (hold)",
+                "id": 120,
+                "type": "button",
+                "vjoy": 4,
+                "button": 24,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_max"
+            },
+            {
+                "name": "Shields - Set to Min (hold)",
+                "id": 125,
+                "type": "button",
+                "vjoy": 4,
+                "button": 25,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_shields_min"
+            },
+            {
+                "name": "Weapons - Increase (tap)",
+                "id": 130,
+                "type": "button",
+                "vjoy": 4,
+                "button": 26,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_increase"
+            },
+            {
+                "name": "Weapons - Decrease (tap)",
+                "id": 135,
+                "type": "button",
+                "vjoy": 4,
+                "button": 27,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_decrease"
+            },
+            {
+                "name": "Weapons - Set to Max (hold)",
+                "id": 140,
+                "type": "button",
+                "vjoy": 4,
+                "button": 28,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_max"
+            },
+            {
+                "name": "Weapons - Set to Min (hold)",
+                "id": 145,
+                "type": "button",
+                "vjoy": 4,
+                "button": 29,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_weapons_min"
+            },
+            {
+                "name": "Reset Assignments",
+                "id": 150,
+                "type": "button",
+                "vjoy": 4,
+                "button": 30,
+                "actionmap": "spaceship_power",
+                "action": "v_engineering_assignment_reset"
+            }
+        ]
+    },
+    {
+        "category_id": 110,
+        "name": "Flight - HUD",
+        "values": [
+            {
+                "name": "Cycle Pitch Ladder Mode",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 31,
+                "actionmap": "spaceship_hud",
+                "action": "v_cycle_pitch_ladder_mode"
+            },
+            {
+                "name": "Scoreboard",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 32,
+                "actionmap": "spaceship_hud",
+                "action": "v_hud_open_scoreboard"
+            },
+            {
+                "name": "Map",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 33,
+                "actionmap": "spaceship_hud",
+                "action": "v_starmap"
+            },
+            {
+                "name": "Wipe Helmet Visor",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 34,
+                "actionmap": "spaceship_hud",
+                "action": "visor_wipe"
+            }
+        ]
+    },
+    {
+        "category_id": 115,
+        "name": "Lights",
+        "values": [
+            {
+                "name": "Headlights (toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 35,
+                "actionmap": "lights_controller",
+                "action": "v_lights"
+            },
+            {
+                "name": "Headlights - On",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 36,
+                "actionmap": "lights_controller",
+                "action": "v_lights_on"
+            },
+            {
+                "name": "Headlights - Off",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 37,
+                "actionmap": "lights_controller",
+                "action": "v_lights_off"
+            }
+        ]
+    },
+    {
+        "category_id": 120,
+        "name": "Ground Vehicle - General",
+        "values": [
+            {
+                "name": "Horn",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 38,
+                "actionmap": "vehicle_general",
+                "action": "v_horn"
+            },
+            {
+                "name": "Cycle Camera View",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 39,
+                "actionmap": "vehicle_general",
+                "action": "v_view_cycle_fwd"
+            },
+            {
+                "name": "Zoom In (3rd Person View)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 40,
+                "actionmap": "vehicle_general",
+                "action": "v_view_zoom_in"
+            },
+            {
+                "name": "Zoom Out (3rd Person View)",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 41,
+                "actionmap": "vehicle_general",
+                "action": "v_view_zoom_out"
+            },
+            {
+                "name": "Look Left/Right",
+                "id": 30,
+                "type": "axis",
+                "vjoy": 3,
+                "axis": 8,
+                "actionmap": "vehicle_general",
+                "action": "v_view_yaw"
+            },
+            {
+                "name": "Look Up/Down",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 1,
+                "actionmap": "vehicle_general",
+                "action": "v_view_pitch"
+            },
+            {
+                "name": "Freelook (Hold)",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 42,
+                "actionmap": "vehicle_general",
+                "action": "v_view_freelook_mode"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 45,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_all"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 50,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_group1"
+            },
+            {
+                "name": "Remap - Control No Longer Available",
+                "id": 55,
+                "type": "button",
+                "vjoy": 0,
+                "button": 0,
+                "disabled": true,
+                "actionmap": "vehicle_general",
+                "action": "v_attack_group2"
+            },
+            {
+                "name": "Flight/Systems Ready",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 43,
+                "actionmap": "vehicle_general",
+                "action": "v_flightready"
+            },
+            {
+                "name": "Open/Close Doors Toggle",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 44,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_doors"
+            },
+            {
+                "name": "Open All Doors",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 45,
+                "actionmap": "vehicle_general",
+                "action": "v_open_all_doors"
+            },
+            {
+                "name": "Close All Doors",
+                "id": 75,
+                "type": "button",
+                "vjoy": 4,
+                "button": 46,
+                "actionmap": "vehicle_general",
+                "action": "v_close_all_doors"
+            },
+            {
+                "name": "Lock/Unlock Doors Toggle",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 47,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_doorlocks"
+            },
+            {
+                "name": "Lock All Doors",
+                "id": 85,
+                "type": "button",
+                "vjoy": 4,
+                "button": 48,
+                "actionmap": "vehicle_general",
+                "action": "v_lock_all_doors"
+            },
+            {
+                "name": "Unlock All Doors",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 49,
+                "actionmap": "vehicle_general",
+                "action": "v_unlock_all_doors"
+            },
+            {
+                "name": "Port Lock Toggle All",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 50,
+                "actionmap": "vehicle_general",
+                "action": "v_toggle_all_portlocks"
+            },
+            {
+                "name": "Port Lock All",
+                "id": 100,
+                "type": "button",
+                "vjoy": 4,
+                "button": 51,
+                "actionmap": "vehicle_general",
+                "action": "v_lock_all_ports"
+            },
+            {
+                "name": "Port Unlock All",
+                "id": 105,
+                "type": "button",
+                "vjoy": 4,
+                "button": 52,
+                "actionmap": "vehicle_general",
+                "action": "v_unlock_all_ports"
+            },
+            {
+                "name": "Map",
+                "id": 110,
+                "type": "button",
+                "vjoy": 4,
+                "button": 53,
+                "actionmap": "vehicle_general",
+                "action": "v_starmap"
+            },
+            {
+                "name": "Wipe Helmet Visor",
+                "id": 115,
+                "type": "button",
+                "vjoy": 4,
+                "button": 54,
+                "actionmap": "vehicle_general",
+                "action": "visor_wipe"
+            }
+        ]
+    },
+    {
+        "category_id": 125,
+        "name": "Ground Vehicle - Movement",
+        "values": [
+            {
+                "name": "Drive Forward",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 55,
+                "actionmap": "vehicle_driver",
+                "action": "v_move_forward"
+            },
+            {
+                "name": "Drive Backward",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 56,
+                "actionmap": "vehicle_driver",
+                "action": "v_move_back"
+            },
+            {
+                "name": "Drive Forward/Backward",
+                "id": 20,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 2,
+                "actionmap": "vehicle_driver",
+                "action": "v_move"
+            },
+            {
+                "name": "Turn Left",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 57,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw_left"
+            },
+            {
+                "name": "Turn Right",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 58,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw_right"
+            },
+            {
+                "name": "Turn Left/Right",
+                "id": 35,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 3,
+                "actionmap": "vehicle_driver",
+                "action": "v_yaw"
+            },
+            {
+                "name": "Pitch Up",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 59,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch_up"
+            },
+            {
+                "name": "Pitch Down",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 60,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch_down"
+            },
+            {
+                "name": "Pitch Up/Down",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 4,
+                "actionmap": "vehicle_driver",
+                "action": "v_pitch"
+            },
+            {
+                "name": "Brake",
+                "id": 55,
+                "type": "button",
+                "vjoy": 4,
+                "button": 61,
+                "actionmap": "vehicle_driver",
+                "action": "v_brake"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (relative)",
+                "id": 60,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 5,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel"
+            },
+            {
+                "name": "Dynamic Zoom In (relative)",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 62,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel_in"
+            },
+            {
+                "name": "Dynamic Zoom Out (relative)",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 63,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_rel_out"
+            },
+            {
+                "name": "Dynamic Zoom In and Out (absolute)",
+                "id": 75,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 6,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_abs"
+            },
+            {
+                "name": "Dynamic Zoom Toggle (absolute)",
+                "id": 80,
+                "type": "button",
+                "vjoy": 4,
+                "button": 64,
+                "actionmap": "vehicle_driver",
+                "action": "v_view_dynamic_zoom_abs_toggle"
+            },
+            {
+                "name": "Boost",
+                "id": 85,
+                "type": "button",
+                "vjoy": 4,
+                "button": 65,
+                "actionmap": "vehicle_driver",
+                "action": "v_boost"
+            },
+            {
+                "name": "Lock Pitch/Yaw Movement (toggle/hold)",
+                "id": 90,
+                "type": "button",
+                "vjoy": 4,
+                "button": 66,
+                "actionmap": "vehicle_driver",
+                "action": "v_lock_rotation"
+            },
+            {
+                "name": "Toggle Brake on Idle",
+                "id": 95,
+                "type": "button",
+                "vjoy": 4,
+                "button": 67,
+                "actionmap": "vehicle_driver",
+                "action": "v_mgv_switch_brake_on_idle"
+            }
+        ]
+    },
+    {
+        "category_id": 130,
+        "name": "Electronic Access - Spectator",
+        "values": [
+            {
+                "name": "Spectator Camera Next Target",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 68,
+                "actionmap": "spectator",
+                "action": "spectate_next_target"
+            },
+            {
+                "name": "Spectator Camera Previous Target",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 69,
+                "actionmap": "spectator",
+                "action": "spectate_prev_target"
+            },
+            {
+                "name": "Spectator Camera Lock Target",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 70,
+                "actionmap": "spectator",
+                "action": "spectate_toggle_lock_target"
+            },
+            {
+                "name": "Spectator Camera Zoom",
+                "id": 25,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 7,
+                "actionmap": "spectator",
+                "action": "spectate_zoom"
+            },
+            {
+                "name": "Spectator Camera Zoom In",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 71,
+                "actionmap": "spectator",
+                "action": "spectate_zoom_in"
+            },
+            {
+                "name": "Spectator Camera Zoom Out",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 72,
+                "actionmap": "spectator",
+                "action": "spectate_zoom_out"
+            },
+            {
+                "name": "Spectator Camera Rotate Yaw",
+                "id": 40,
+                "type": "axis",
+                "vjoy": 4,
+                "axis": 8,
+                "actionmap": "spectator",
+                "action": "spectate_rotateyaw"
+            },
+            {
+                "name": "Spectator Camera Rotate Pitch",
+                "id": 45,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 1,
+                "actionmap": "spectator",
+                "action": "spectate_rotatepitch"
+            },
+            {
+                "name": "Spectator Camera Rotate Yaw (Mouse)",
+                "id": 50,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 2,
+                "actionmap": "spectator",
+                "action": "spectate_rotateyaw_mouse"
+            },
+            {
+                "name": "Spectator Camera Rotate Pitch (Mouse)",
+                "id": 55,
+                "type": "axis",
+                "vjoy": 5,
+                "axis": 3,
+                "actionmap": "spectator",
+                "action": "spectate_rotatepitch_mouse"
+            },
+            {
+                "name": "Spectator Camera HUD (toggle)",
+                "id": 60,
+                "type": "button",
+                "vjoy": 4,
+                "button": 73,
+                "actionmap": "spectator",
+                "action": "spectate_toggle_hud"
+            },
+            {
+                "name": "Spectator Camera Mode - Next",
+                "id": 65,
+                "type": "button",
+                "vjoy": 4,
+                "button": 74,
+                "actionmap": "spectator",
+                "action": "spectate_gen_nextmode"
+            },
+            {
+                "name": "Spectator Camera Mode - Previous",
+                "id": 70,
+                "type": "button",
+                "vjoy": 4,
+                "button": 75,
+                "actionmap": "spectator",
+                "action": "spectate_gen_prevmode"
+            }
+        ]
+    },
+    {
+        "category_id": 135,
+        "name": "Social - General",
+        "values": [
+            {
+                "name": "Re-Spawn",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 76,
+                "actionmap": "default",
+                "action": "respawn"
+            },
+            {
+                "name": "Exit Seat",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 77,
+                "actionmap": "default",
+                "action": "pl_exit"
+            },
+            {
+                "name": "Notification Accept",
+                "id": 17,
+                "type": "button",
+                "vjoy": 4,
+                "button": 78,
+                "actionmap": "default",
+                "action": "notification_accept"
+            },
+            {
+                "name": "Notification Decline",
+                "id": 18,
+                "type": "button",
+                "vjoy": 4,
+                "button": 79,
+                "actionmap": "default",
+                "action": "notification_decline"
+            },
+            {
+                "name": "CommLink App",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 80,
+                "actionmap": "default",
+                "action": "toggle_contact"
+            },
+            {
+                "name": "Chat Window",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 81,
+                "actionmap": "default",
+                "action": "toggle_chat"
+            },
+            {
+                "name": "Chat Window Focus",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 82,
+                "actionmap": "default",
+                "action": "focus_on_chat_textinput"
+            },
+            {
+                "name": "Chat Cycle Lobby",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 83,
+                "actionmap": "default",
+                "action": "cycle_chat_lobby"
+            }
+        ]
+    },
+    {
+        "category_id": 140,
+        "name": "VOIP, FOIP and Head Tracking",
+        "values": [
+            {
+                "name": "VR - Toggle On/Off",
+                "id": 1,
+                "type": "button",
+                "vjoy": 4,
+                "button": 84,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_toggle"
+            },
+            {
+                "name": "VR - Recenter Device",
+                "id": 2,
+                "type": "button",
+                "vjoy": 4,
+                "button": 85,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_recenter"
+            },
+            {
+                "name": "VR - Toggle Theater Mode",
+                "id": 5,
+                "type": "button",
+                "vjoy": 4,
+                "button": 86,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_theater_mode_toggle"
+            },
+            {
+                "name": "VR - Toggle Visor On/Off",
+                "id": 6,
+                "type": "button",
+                "vjoy": 4,
+                "button": 87,
+                "actionmap": "player_input_optical_tracking",
+                "action": "hmd_lens_display_toggle"
+            },
+            {
+                "name": "Enable Head Tracking (toggle)",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 88,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_enabled"
+            },
+            {
+                "name": "Head Tracking (hold)",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 89,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_hold"
+            },
+            {
+                "name": "Recenter Head Tracking Device (except TrackIR)",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 90,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_recenter_device"
+            },
+            {
+                "name": "Enable/Disable Head Tracking for 3rd Person Camera",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 91,
+                "actionmap": "player_input_optical_tracking",
+                "action": "headtrack_camera_enabled"
+            },
+            {
+                "name": "VOIP Push to Talk",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 92,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_pushtotalk"
+            },
+            {
+                "name": "VOIP Push to Talk (Proximity Only)",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 93,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_pushtotalk_proximity"
+            },
+            {
+                "name": "FOIP Selfie Cam",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 94,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_viewownplayer"
+            },
+            {
+                "name": "FOIP Recalibrate",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 95,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_recalibrate"
+            },
+            {
+                "name": "Cycle through Audio Channels",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 96,
+                "actionmap": "player_input_optical_tracking",
+                "action": "foip_cyclechannel"
+            }
+        ]
+    },
+    {
+        "category_id": 150,
+        "name": "Quick Keys, Interactions and Inner Thoughts",
+        "values": [
+            {
+                "name": "Focus",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 97,
+                "actionmap": "player_choice",
+                "action": "pc_focus"
+            },
+            {
+                "name": "Interaction Mode",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 98,
+                "actionmap": "player_choice",
+                "action": "pc_interaction_mode"
+            },
+            {
+                "name": "Interaction Select",
+                "id": 16,
+                "type": "button",
+                "vjoy": 4,
+                "button": 99,
+                "actionmap": "player_choice",
+                "action": "pc_interaction_select"
+            },
+            {
+                "name": "Activate Inner Thought",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 100,
+                "actionmap": "player_choice",
+                "action": "pc_select"
+            },
+            {
+                "name": "Interaction Mode Zoom In",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 101,
+                "actionmap": "player_choice",
+                "action": "pc_zoom_in"
+            },
+            {
+                "name": "Interaction Mode Zoom Out",
+                "id": 30,
+                "type": "button",
+                "vjoy": 4,
+                "button": 102,
+                "actionmap": "player_choice",
+                "action": "pc_zoom_out"
+            },
+            {
+                "name": "MFD Left",
+                "id": 35,
+                "type": "button",
+                "vjoy": 4,
+                "button": 103,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_left"
+            },
+            {
+                "name": "MFD Right",
+                "id": 40,
+                "type": "button",
+                "vjoy": 4,
+                "button": 104,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_right"
+            },
+            {
+                "name": "MFD Up",
+                "id": 45,
+                "type": "button",
+                "vjoy": 4,
+                "button": 105,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_up"
+            },
+            {
+                "name": "MFD Down",
+                "id": 50,
+                "type": "button",
+                "vjoy": 4,
+                "button": 106,
+                "actionmap": "player_choice",
+                "action": "pc_screen_focus_down"
+            },
+            {
+                "name": "Exit",
+                "id": 55,
+                "type": "button",
+                "vjoy": 4,
+                "button": 107,
+                "actionmap": "player_choice",
+                "action": "pc_personal_back"
+            }
+        ]
+    },
+    {
+        "category_id": 160,
+        "name": "Camera - Advanced Camera Controls",
+        "values": [
+            {
+                "name": "Increase FOV",
+                "id": 10,
+                "type": "button",
+                "vjoy": 4,
+                "button": 108,
+                "actionmap": "view_director_mode",
+                "action": "view_fov_in"
+            },
+            {
+                "name": "Decrease FOV",
+                "id": 15,
+                "type": "button",
+                "vjoy": 4,
+                "button": 109,
+                "actionmap": "view_director_mode",
+                "action": "view_fov_out"
+            },
+            {
+                "name": "Increase DoF",
+                "id": 16,
+                "type": "button",
+                "vjoy": 4,
+                "button": 110,
+                "actionmap": "view_director_mode",
+                "action": "view_fstop_in"
+            },
+            {
+                "name": "Decrease DoF",
+                "id": 20,
+                "type": "button",
+                "vjoy": 4,
+                "button": 111,
+                "actionmap": "view_director_mode",
+                "action": "view_fstop_out"
+            },
+            {
+                "name": "Reset Current View",
+                "id": 25,
+                "type": "button",
+                "vjoy": 4,
+                "button": 112,
+                "actionmap": "view_director_mode",
+                "action": "view_restore_defaults"
+            }
+        ]
+    }
+]

--- a/generate_wix.py
+++ b/generate_wix.py
@@ -227,7 +227,7 @@ def create_document():
             #"Id": "6472cca8-d352-4186-8a98-ca6ba33d083c", # 13.40.6ex
             #"Id": "7cdb8375-66a1-4114-be79-b17027e8c0df", # 13.40.7ex
             #"Id": "739095a7-19cc-4154-ac9c-c51f5f516527", # 13.40.8ex
-            "ProductCode": "8b262810-5e62-4452-b5cd-968738327d97", # 13.40.14-sc.4
+            "ProductCode": "0b4945df-91ac-4287-96fa-4e336af5ede6", # 13.40.14-sc.5
             "UpgradeCode": "1f5d614b-6cec-47d8-90e3-40f7e7458f7a",
             "Language": "1033",
             "Codepage": "1252",

--- a/gremlin/ui/sc_vjoy_mapper.py
+++ b/gremlin/ui/sc_vjoy_mapper.py
@@ -65,7 +65,7 @@ class ScVjoyMapperUI(gremlin.ui.ui_common.BaseDialogUi):
         self.vjoy_ordering_textbox.setFixedWidth(100)
         self.vjoy_ordering_textbox.textEdited.connect(self._update_vjoy_ordering)
         vjoy_ordering_edit.addWidget(self.vjoy_ordering_textbox)
-        vjoy_ordering_edit.addWidget(QtWidgets.QLabel("(Enter 5 numbers (1-5) separated by commas)"))
+        vjoy_ordering_edit.addWidget(QtWidgets.QLabel("(Enter up to 8 numbers separated by commas - based on # of Vjoys used)"))
 
         vjoy_ordering_layout = QtWidgets.QFormLayout()
         vjoy_ordering_layout.addRow(vjoy_ordering_labels, vjoy_ordering_edit)
@@ -109,7 +109,7 @@ class ScVjoyMapperUI(gremlin.ui.ui_common.BaseDialogUi):
         instruction_button = QtWidgets.QPushButton("6. Click HERE to run Mapper")
         instruction_button.clicked.connect(self._run_sc_mapper)
         instruction_layout.addWidget(instruction_button)
-        instruction_layout.addWidget(QtWidgets.QLabel("WARNING: 4.0.x fails to import MFD bindings through the UI.\nUse the following command (press `) to import: 'pp_RebindKeys layout_JG_StarCitizenMapping_4-0-x_layout'\n"))
+        instruction_layout.addWidget(QtWidgets.QLabel("WARNING: 4.x.x fails to import MFD bindings through the UI.\nUse the following command (press `) to import: 'pp_RebindKeys layout_JG_StarCitizenMapping_4-x-x_layout'\n"))
         self.main_layout.addLayout(instruction_layout)
 
 
@@ -152,8 +152,8 @@ class ScVjoyMapperUI(gremlin.ui.ui_common.BaseDialogUi):
         self.logger.debug(f"SC Installation: {self.sc_installation}")
 
         vjoy_order = self.vjoy_ordering.split(",")
-        if self._match(self.vjoy_ordering) == False or len(vjoy_order) != 5:
-            gremlin.util.display_error("vJoy Order must have 5 numbers (1-8) separated by commas")
+        if self._match(self.vjoy_ordering) == False or len(vjoy_order) > 8:
+            gremlin.util.display_error("vJoy Order can't have more than 8 numbers (1-8) separated by commas")
             return
 
         if os.path.exists(self.base_control_profile) == False or self.base_control_profile.endswith(".xml") == False:

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -79,7 +79,7 @@ install_path = os.path.normcase(os.path.dirname(os.path.abspath(sys.argv[0])))
 os.chdir(install_path)
 
 APPLICATION_NAME = "Joystick Gremlin SC"
-APPLICATION_VERSION = "13.40.14-sc.4"
+APPLICATION_VERSION = "13.40.14-sc.5"
 
 from gremlin.singleton_decorator import SingletonDecorator
 


### PR DESCRIPTION
Included in this release:
* Fix to Response Curve not displaying correctly
* Fix for when joysticks are unplugged and JG is activated
* Update vJoyMapper to support up to 8 vJoys
* Added support for Star Citizen 4.6.x
  *  Mappings added:
     * Light Amplification Toggle
     * Light Amplification On
     * Light Amplification Off